### PR TITLE
Добавление поля 'functions_state_id' в MessagesChunk

### DIFF
--- a/src/gigachat/models/messages_chunk.py
+++ b/src/gigachat/models/messages_chunk.py
@@ -14,3 +14,5 @@ class MessagesChunk(BaseModel):
     """Текст сообщения"""
     function_call: Optional[FunctionCall] = None
     """Вызов функции"""
+    functions_state_id: str = None
+    """Идентификатор вызова функции"""


### PR DESCRIPTION
Поле 'functions_state_id' GigaChat отдает, если была вызвана функция. Если его не отдавать клиенту и не хранить на клиенте, то последующие вызовы в сессии могут не совсем корректно обрабатываться GigaChat'ом.