### PR TITLE
Add throttled async client with configurable concurrency limits

### DIFF
--- a/src/gigachat/client.py
+++ b/src/gigachat/client.py
@@ -1,5 +1,7 @@
+import asyncio
 import logging
 import ssl
+from contextlib import asynccontextmanager
 from functools import cached_property
 from typing import (
     Any,
@@ -122,6 +124,47 @@ def _build_access_token(token: Token) -> AccessToken:
     return AccessToken(access_token=token.tok, expires_at=token.exp, x_headers=token.x_headers)
 
 
+class ThrottledAsyncClient(httpx.AsyncClient):
+    """Async client that limits the number of concurrent requests."""
+
+    def __init__(self, *args: Any, max_connections: Optional[int] = None, **kwargs: Any) -> None:
+        if max_connections is not None and max_connections <= 0:
+            raise ValueError("max_connections must be a positive integer")
+        super().__init__(*args, **kwargs)
+        self._max_connections_limit = max_connections
+        self._semaphore: Optional[asyncio.Semaphore]
+        if max_connections is None:
+            self._semaphore = None
+        else:
+            self._semaphore = asyncio.Semaphore(max_connections)
+
+    @property
+    def max_connections_limit(self) -> Optional[int]:
+        return self._max_connections_limit
+
+    async def request(self, *args: Any, **kwargs: Any) -> httpx.Response:  # type: ignore[override]
+        if self._semaphore is None:
+            return await super().request(*args, **kwargs)
+        await self._semaphore.acquire()
+        try:
+            return await super().request(*args, **kwargs)
+        finally:
+            self._semaphore.release()
+
+    @asynccontextmanager
+    async def stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[httpx.Response]:  # type: ignore[override]
+        if self._semaphore is None:
+            async with super().stream(*args, **kwargs) as response:
+                yield response
+            return
+        await self._semaphore.acquire()
+        try:
+            async with super().stream(*args, **kwargs) as response:
+                yield response
+        finally:
+            self._semaphore.release()
+
+
 class _BaseClient:
     _access_token: Optional[AccessToken] = None
 
@@ -146,6 +189,8 @@ class _BaseClient:
         key_file_password: Optional[str] = None,
         ssl_context: Optional[ssl.SSLContext] = None,
         flags: Optional[List[str]] = None,
+        max_connections: Optional[int] = None,
+        max_auth_connections: Optional[int] = None,
         **_unknown_kwargs: Any,
     ) -> None:
         if _unknown_kwargs:
@@ -170,6 +215,8 @@ class _BaseClient:
             "key_file_password": key_file_password,
             "ssl_context": ssl_context,
             "flags": flags,
+            "max_connections": max_connections,
+            "max_auth_connections": max_auth_connections,
         }
         config = {k: v for k, v in kwargs.items() if v is not None}
         self._settings = Settings(**config)
@@ -364,12 +411,18 @@ class GigaChatAsyncClient(_BaseClient):
         self.a_threads = ThreadsAsyncClient(self)
 
     @cached_property
-    def _aclient(self) -> httpx.AsyncClient:
-        return httpx.AsyncClient(**_get_kwargs(self._settings))
+    def _aclient(self) -> ThrottledAsyncClient:
+        return ThrottledAsyncClient(
+            **_get_kwargs(self._settings),
+            max_connections=self._settings.max_connections,
+        )
 
     @cached_property
-    def _auth_aclient(self) -> httpx.AsyncClient:
-        return httpx.AsyncClient(**_get_auth_kwargs(self._settings))
+    def _auth_aclient(self) -> ThrottledAsyncClient:
+        return ThrottledAsyncClient(
+            **_get_auth_kwargs(self._settings),
+            max_connections=self._settings.max_auth_connections,
+        )
 
     async def aclose(self) -> None:
         await self._aclient.aclose()

--- a/src/gigachat/settings.py
+++ b/src/gigachat/settings.py
@@ -32,6 +32,12 @@ class Settings(BaseSettings):
     timeout: float = 30.0
     verify_ssl_certs: bool = True
 
+    max_connections: Optional[int] = None
+    """Максимальное количество одновременных запросов"""
+
+    max_auth_connections: Optional[int] = None
+    """Максимальное количество одновременных запросов авторизации"""
+
     verbose: bool = False
 
     ssl_context: Optional[ssl.SSLContext] = None

--- a/tests/unit_tests/gigachat/test_client.py
+++ b/tests/unit_tests/gigachat/test_client.py
@@ -1,7 +1,9 @@
+import asyncio
 import ssl
 from typing import List, Optional
 
 import pytest
+import httpx
 from pytest_httpx import HTTPXMock
 from pytest_mock import MockerFixture
 
@@ -10,6 +12,7 @@ from gigachat.client import (
     GIGACHAT_MODEL,
     GigaChatAsyncClient,
     GigaChatSyncClient,
+    ThrottledAsyncClient,
     _get_auth_kwargs,
     _get_kwargs,
     _logger,
@@ -105,6 +108,53 @@ def test__get_auth_kwargs_ssl() -> None:
     context = _make_ssl_context()
     settings = Settings(ssl_context=context)
     assert _get_kwargs(settings)["verify"] == context
+
+
+@pytest.mark.asyncio()
+async def test_async_client_uses_throttled_client() -> None:
+    async with GigaChatAsyncClient(base_url=BASE_URL) as client:
+        assert isinstance(client._aclient, ThrottledAsyncClient)
+        assert isinstance(client._auth_aclient, ThrottledAsyncClient)
+
+
+@pytest.mark.asyncio()
+async def test_async_client_limits_configuration() -> None:
+    async with GigaChatAsyncClient(
+        base_url=BASE_URL,
+        max_connections=2,
+        max_auth_connections=3,
+    ) as client:
+        assert client._aclient.max_connections_limit == 2
+        assert client._auth_aclient.max_connections_limit == 3
+
+
+@pytest.mark.asyncio()
+async def test_throttled_async_client_limits_requests(mocker: MockerFixture) -> None:
+    concurrency = 0
+    max_seen = 0
+
+    async def fake_request(
+        self: httpx.AsyncClient, *args: object, **kwargs: object
+    ) -> httpx.Response:
+        nonlocal concurrency, max_seen
+        concurrency += 1
+        max_seen = max(max_seen, concurrency)
+        await asyncio.sleep(0)
+        concurrency -= 1
+        return httpx.Response(200, request=httpx.Request("GET", "http://test"))
+
+    mocker.patch.object(httpx.AsyncClient, "request", fake_request)
+
+    client = GigaChatAsyncClient(base_url=BASE_URL, max_connections=1)
+    try:
+        await asyncio.gather(
+            client._aclient.request("GET", "http://test"),
+            client._aclient.request("GET", "http://test"),
+        )
+    finally:
+        await client.aclose()
+
+    assert max_seen == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/gigachat/test_settings.py
+++ b/tests/unit_tests/gigachat/test_settings.py
@@ -3,3 +3,9 @@ from gigachat.settings import Settings
 
 def test_settings() -> None:
     assert Settings()
+
+
+def test_settings_limits() -> None:
+    settings = Settings(max_connections=1, max_auth_connections=2)
+    assert settings.max_connections == 1
+    assert settings.max_auth_connections == 2


### PR DESCRIPTION
## Summary
- add a ThrottledAsyncClient that limits concurrent async API calls
- expose max_connections and max_auth_connections settings and wire them into async clients
- extend unit tests to cover throttling behavior and new settings fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690c86c740e88331ac4fbe3e20fa8ae7