### PR TITLE
Add configurable connection limits for GigaChat clients

### DIFF
--- a/src/gigachat/client.py
+++ b/src/gigachat/client.py
@@ -77,6 +77,11 @@ def _get_kwargs(settings: Settings) -> Dict[str, Any]:
         "verify": settings.verify_ssl_certs,
         "timeout": httpx.Timeout(settings.timeout),
     }
+    if settings.max_connections is not None:
+        kwargs["limits"] = httpx.Limits(
+            max_connections=settings.max_connections,
+            max_keepalive_connections=settings.max_connections,
+        )
     if settings.ssl_context:
         kwargs["verify"] = settings.ssl_context
     if settings.ca_bundle_file:
@@ -96,6 +101,11 @@ def _get_auth_kwargs(settings: Settings) -> Dict[str, Any]:
         "verify": settings.verify_ssl_certs,
         "timeout": httpx.Timeout(settings.timeout),
     }
+    if settings.max_auth_connections is not None:
+        kwargs["limits"] = httpx.Limits(
+            max_connections=settings.max_auth_connections,
+            max_keepalive_connections=settings.max_auth_connections,
+        )
     if settings.ssl_context:
         kwargs["verify"] = settings.ssl_context
     if settings.ca_bundle_file:
@@ -146,6 +156,8 @@ class _BaseClient:
         key_file_password: Optional[str] = None,
         ssl_context: Optional[ssl.SSLContext] = None,
         flags: Optional[List[str]] = None,
+        max_connections: Optional[int] = None,
+        max_auth_connections: Optional[int] = None,
         **_unknown_kwargs: Any,
     ) -> None:
         if _unknown_kwargs:
@@ -170,6 +182,8 @@ class _BaseClient:
             "key_file_password": key_file_password,
             "ssl_context": ssl_context,
             "flags": flags,
+            "max_connections": max_connections,
+            "max_auth_connections": max_auth_connections,
         }
         config = {k: v for k, v in kwargs.items() if v is not None}
         self._settings = Settings(**config)

--- a/src/gigachat/settings.py
+++ b/src/gigachat/settings.py
@@ -41,5 +41,11 @@ class Settings(BaseSettings):
     key_file_password: Optional[str] = None
     flags: Optional[List[str]] = None
 
+    max_connections: Optional[int] = None
+    """Максимальное количество одновременных соединений с API GigaChat"""
+
+    max_auth_connections: Optional[int] = None
+    """Максимальное количество одновременных соединений с сервером авторизации"""
+
     class Config:
         env_prefix = ENV_PREFIX

--- a/tests/unit_tests/gigachat/test_client.py
+++ b/tests/unit_tests/gigachat/test_client.py
@@ -90,6 +90,13 @@ def test__get_kwargs() -> None:
     assert _get_kwargs(settings)
 
 
+def test__get_kwargs_limits() -> None:
+    settings = Settings(max_connections=3)
+    limits = _get_kwargs(settings)["limits"]
+    assert limits.max_connections == 3
+    assert limits.max_keepalive_connections == 3
+
+
 def test__get_kwargs_ssl() -> None:
     context = _make_ssl_context()
     settings = Settings(ssl_context=context)
@@ -99,6 +106,13 @@ def test__get_kwargs_ssl() -> None:
 def test__get_auth_kwargs() -> None:
     settings = Settings(ca_bundle_file="ca.pem", cert_file="tls.pem", key_file="tls.key")
     assert _get_auth_kwargs(settings)
+
+
+def test__get_auth_kwargs_limits() -> None:
+    settings = Settings(max_auth_connections=2)
+    limits = _get_auth_kwargs(settings)["limits"]
+    assert limits.max_connections == 2
+    assert limits.max_keepalive_connections == 2
 
 
 def test__get_auth_kwargs_ssl() -> None:

--- a/tests/unit_tests/gigachat/test_settings.py
+++ b/tests/unit_tests/gigachat/test_settings.py
@@ -3,3 +3,13 @@ from gigachat.settings import Settings
 
 def test_settings() -> None:
     assert Settings()
+
+
+def test_settings_env(monkeypatch) -> None:
+    monkeypatch.setenv("GIGACHAT_MAX_CONNECTIONS", "5")
+    monkeypatch.setenv("GIGACHAT_MAX_AUTH_CONNECTIONS", "7")
+
+    settings = Settings()
+
+    assert settings.max_connections == 5
+    assert settings.max_auth_connections == 7


### PR DESCRIPTION
## Summary
- add settings to configure maximum API and auth connections via constructor parameters or environment variables
- wire configured connection limits into sync and async httpx clients
- extend unit tests to cover the new configuration options

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_690caa07237c8331996a5d07154e8c83