### PR TITLE
chore: add update_settings method to _BaseClient

### DIFF
--- a/src/gigachat/client.py
+++ b/src/gigachat/client.py
@@ -203,6 +203,21 @@ class _BaseClient:
         """Сбросить токен"""
         self._access_token = None
 
+    @property
+    def settings(self):
+        return self._settings
+
+    @settings.setter
+    def settings(self, value: Settings) -> None:
+        if not isinstance(value, Settings):
+            raise TypeError(f"Expected Settings, got {type(value)}")
+
+        self._settings = value
+
+    def update_settings(self, **kwargs):
+        """Безопасное обновление полей Settings"""
+        self._settings = self._settings.copy(update=kwargs)
+
 
 class GigaChatSyncClient(_BaseClient):
     """Синхронный клиент GigaChat"""


### PR DESCRIPTION
This pull request adds new functionality for managing client settings in the `src/gigachat/client.py` file. The changes introduce a property interface for accessing and updating the `settings` attribute, along with a method for safely updating individual settings fields.

Settings management improvements:

* Added a `settings` property with getter and setter methods to the client class, including type checking to ensure only `Settings` objects are assigned.
* Implemented an `update_settings` method to safely update fields of the `Settings` object using keyword arguments.