### PR TITLE
feat: add batch API support and file content retrieval

### DIFF
--- a/examples/example_batching.ipynb
+++ b/examples/example_batching.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "batching-title",
+   "metadata": {},
+   "source": [
+    "# Batching Example\n",
+    "\n",
+    "This notebook demonstrates how to create a batch request, track its status, and download the resulting output file with the GigaChat API.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "batching-imports-text",
+   "metadata": {},
+   "source": [
+    "Import required libraries for working with batch files and the GigaChat client.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "batching-imports-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import base64\n",
+    "import getpass\n",
+    "import os\n",
+    "\n",
+    "from gigachat import GigaChat\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "batching-credentials-text",
+   "metadata": {},
+   "source": [
+    "Set up GigaChat credentials and scope. The input will be hidden for security.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "batching-credentials-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if \"GIGACHAT_CREDENTIALS\" not in os.environ:\n",
+    "    os.environ[\"GIGACHAT_CREDENTIALS\"] = getpass.getpass(\"GigaChat Credentials: \")\n",
+    "\n",
+    "if \"GIGACHAT_SCOPE\" not in os.environ:\n",
+    "    os.environ[\"GIGACHAT_SCOPE\"] = getpass.getpass(\"GigaChat Scope: \")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "batching-input-text",
+   "metadata": {},
+   "source": [
+    "## Load Batch Input File\n",
+    "\n",
+    "Read a JSONL file with batch requests. The API currently supports up to 500 lines per file.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "batching-input-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"batch_file_500.jsonl\", \"rb\") as f:\n",
+    "    data = f.read()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "batching-create-text",
+   "metadata": {},
+   "source": [
+    "## Create Batch\n",
+    "\n",
+    "Create a batch using the appropriate method for your file, such as `chat_completions` or `embedder`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "batching-create-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with GigaChat(verify_ssl_certs=False) as giga:\n",
+    "    batch_creation = giga.create_batch(data, method=\"chat_completions\")\n",
+    "    print(batch_creation)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "batching-status-text",
+   "metadata": {},
+   "source": [
+    "## Check Batch Status\n",
+    "\n",
+    "Batch jobs move through `created`, `in_progress`, and `completed` states. Use `get_batches` to poll the current status.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "batching-status-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with GigaChat(verify_ssl_certs=False) as giga:\n",
+    "    result = giga.get_batches(batch_id=batch_creation.id_)\n",
+    "    print(result)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "batching-output-text",
+   "metadata": {},
+   "source": [
+    "## Download And Decode Output\n",
+    "\n",
+    "After the batch completes, use the `output_file_id` field to fetch the output file content, decode the base64 payload, and save it as a JSONL file.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "batching-output-code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with GigaChat(verify_ssl_certs=False) as giga:\n",
+    "    output_file = giga.get_file_content(result.output_file_id)\n",
+    "\n",
+    "decoded = base64.b64decode(output_file.content)\n",
+    "\n",
+    "with open(\"batch_answers_500.jsonl\", \"wb\") as f:\n",
+    "    f.write(decoded)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "batching-empty",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/example_batching.ipynb
+++ b/examples/example_batching.ipynb
@@ -137,7 +137,7 @@
    "outputs": [],
    "source": [
     "with GigaChat(verify_ssl_certs=False) as giga:\n",
-    "    output_file = giga.get_file_content(result.output_file_id)\n",
+    "    output_file = giga.get_file_content(result.batches[0].output_file_id)\n",
     "\n",
     "decoded = base64.b64decode(output_file.content)\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gigachat"
-version = "0.2.0"
+version = "0.2.1"
 description = "GigaChat. Python-library for GigaChat API"
 authors = [
     { name = "Konstantin Krestnikov", email = "rai220@gmail.com" },

--- a/src/gigachat/__init__.py
+++ b/src/gigachat/__init__.py
@@ -14,6 +14,8 @@ from gigachat.exceptions import (
     ServerError,
 )
 from gigachat.models import (
+    Batch,
+    Batches,
     Chat,
     ChatCompletion,
     ChatCompletionChunk,
@@ -43,6 +45,8 @@ __all__ = [
     "NotFoundError",
     "RequestEntityTooLargeError",
     "ServerError",
+    "Batch",
+    "Batches",
     "Chat",
     "ChatCompletion",
     "ChatCompletionChunk",

--- a/src/gigachat/__init__.py
+++ b/src/gigachat/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from importlib.metadata import PackageNotFoundError, version
 
 from gigachat.client import GigaChat, GigaChatAsyncClient, GigaChatSyncClient
 from gigachat.context import custom_headers_cvar, request_id_cvar, session_id_cvar
@@ -32,7 +33,13 @@ from gigachat.models import (
     Usage,
 )
 
+try:
+    __version__ = version("gigachat")
+except PackageNotFoundError:
+    __version__ = "0.2.1"
+
 __all__ = [
+    "__version__",
     "GigaChat",
     "GigaChatSyncClient",
     "GigaChatAsyncClient",

--- a/src/gigachat/api/__init__.py
+++ b/src/gigachat/api/__init__.py
@@ -1,6 +1,7 @@
 from gigachat.api import (
     assistants,
     auth,
+    batches,
     chat,
     embeddings,
     files,
@@ -13,6 +14,7 @@ from gigachat.api import (
 __all__ = [
     "assistants",
     "auth",
+    "batches",
     "chat",
     "embeddings",
     "files",

--- a/src/gigachat/api/batches.py
+++ b/src/gigachat/api/batches.py
@@ -1,9 +1,15 @@
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 
 import httpx
 
 from gigachat._types import FileContent
-from gigachat.api.utils import build_headers, execute_request_async, execute_request_sync
+from gigachat.api.utils import (
+    _raise_for_status,
+    build_headers,
+    build_x_headers,
+    execute_request_async,
+    execute_request_sync,
+)
 from gigachat.models.batches import Batch, Batches
 
 
@@ -78,6 +84,24 @@ def _get_batches_kwargs(
     }
 
 
+def _parse_batches_payload(payload: Union[Dict[str, Any], List[Dict[str, Any]]]) -> Dict[str, Any]:
+    if isinstance(payload, list):
+        return {"batches": payload}
+    if "batches" in payload:
+        return payload
+    if "id" in payload:
+        return {"batches": [payload]}
+    return payload
+
+
+def _build_batches_response(response: httpx.Response) -> Batches:
+    if response.status_code != 200:
+        _raise_for_status(response.url, response.status_code, response.content, response.headers)
+
+    payload = _parse_batches_payload(response.json())
+    return Batches(x_headers=build_x_headers(response), **payload)
+
+
 def get_batches_sync(
     client: httpx.Client,
     *,
@@ -86,7 +110,8 @@ def get_batches_sync(
 ) -> Batches:
     """Return batch tasks or a specific batch task."""
     kwargs = _get_batches_kwargs(batch_id=batch_id, access_token=access_token)
-    return execute_request_sync(client, kwargs, Batches)
+    response = client.request(**kwargs)
+    return _build_batches_response(response)
 
 
 async def get_batches_async(
@@ -97,4 +122,5 @@ async def get_batches_async(
 ) -> Batches:
     """Return batch tasks or a specific batch task."""
     kwargs = _get_batches_kwargs(batch_id=batch_id, access_token=access_token)
-    return await execute_request_async(client, kwargs, Batches)
+    response = await client.request(**kwargs)
+    return _build_batches_response(response)

--- a/src/gigachat/api/batches.py
+++ b/src/gigachat/api/batches.py
@@ -1,0 +1,100 @@
+from typing import Any, Dict, Literal, Optional
+
+import httpx
+
+from gigachat._types import FileContent
+from gigachat.api.utils import build_headers, execute_request_async, execute_request_sync
+from gigachat.models.batches import Batch, Batches
+
+
+def _get_batch_content(file: FileContent) -> bytes:
+    if isinstance(file, bytes):
+        return file
+    if isinstance(file, str):
+        return file.encode("utf-8")
+
+    content = file.read()
+    if isinstance(content, bytes):
+        return content
+    return content.encode("utf-8")
+
+
+def _create_batch_kwargs(
+    *,
+    file: FileContent,
+    method: Literal["chat_completions", "embedder"],
+    access_token: Optional[str] = None,
+) -> Dict[str, Any]:
+    headers = build_headers(access_token)
+    headers["Content-Type"] = "application/octet-stream"
+
+    return {
+        "method": "POST",
+        "url": "/batches",
+        "content": _get_batch_content(file),
+        "params": {"method": method},
+        "headers": headers,
+    }
+
+
+def create_batch_sync(
+    client: httpx.Client,
+    *,
+    file: FileContent,
+    method: Literal["chat_completions", "embedder"],
+    access_token: Optional[str] = None,
+) -> Batch:
+    """Create a batch task for asynchronous processing."""
+    kwargs = _create_batch_kwargs(file=file, method=method, access_token=access_token)
+    return execute_request_sync(client, kwargs, Batch)
+
+
+async def create_batch_async(
+    client: httpx.AsyncClient,
+    *,
+    file: FileContent,
+    method: Literal["chat_completions", "embedder"],
+    access_token: Optional[str] = None,
+) -> Batch:
+    """Create a batch task for asynchronous processing."""
+    kwargs = _create_batch_kwargs(file=file, method=method, access_token=access_token)
+    return await execute_request_async(client, kwargs, Batch)
+
+
+def _get_batches_kwargs(
+    *,
+    batch_id: Optional[str] = None,
+    access_token: Optional[str] = None,
+) -> Dict[str, Any]:
+    headers = build_headers(access_token)
+    headers["Content-Type"] = "application/json"
+
+    params = {"batch_id": batch_id} if batch_id is not None else None
+    return {
+        "method": "GET",
+        "url": "/batches",
+        "params": params,
+        "headers": headers,
+    }
+
+
+def get_batches_sync(
+    client: httpx.Client,
+    *,
+    batch_id: Optional[str] = None,
+    access_token: Optional[str] = None,
+) -> Batches:
+    """Return batch tasks or a specific batch task."""
+    kwargs = _get_batches_kwargs(batch_id=batch_id, access_token=access_token)
+    return execute_request_sync(client, kwargs, Batches)
+
+
+async def get_batches_async(
+    client: httpx.AsyncClient,
+    *,
+    batch_id: Optional[str] = None,
+    access_token: Optional[str] = None,
+) -> Batches:
+    """Return batch tasks or a specific batch task."""
+    kwargs = _get_batches_kwargs(batch_id=batch_id, access_token=access_token)
+    return await execute_request_async(client, kwargs, Batches)

--- a/src/gigachat/api/files.py
+++ b/src/gigachat/api/files.py
@@ -8,7 +8,7 @@ import httpx
 from gigachat._types import FileTypes
 from gigachat.api.utils import build_headers, build_x_headers, execute_request_async, execute_request_sync
 from gigachat.exceptions import AuthenticationError, ResponseError
-from gigachat.models.files import DeletedFile, File, Image, UploadedFile, UploadedFiles
+from gigachat.models.files import DeletedFile, File, UploadedFile, UploadedFiles
 
 
 def _get_file_kwargs(

--- a/src/gigachat/api/files.py
+++ b/src/gigachat/api/files.py
@@ -1,4 +1,5 @@
 import base64
+import warnings
 from http import HTTPStatus
 from typing import Any, Dict, Literal, Optional
 
@@ -7,7 +8,7 @@ import httpx
 from gigachat._types import FileTypes
 from gigachat.api.utils import build_headers, build_x_headers, execute_request_async, execute_request_sync
 from gigachat.exceptions import AuthenticationError, ResponseError
-from gigachat.models.files import DeletedFile, Image, UploadedFile, UploadedFiles
+from gigachat.models.files import DeletedFile, File, Image, UploadedFile, UploadedFiles
 
 
 def _get_file_kwargs(
@@ -153,7 +154,7 @@ async def delete_file_async(
     return await execute_request_async(client, kwargs, DeletedFile)
 
 
-def _get_image_kwargs(
+def _get_file_content_kwargs(
     *,
     file_id: str,
     access_token: Optional[str] = None,
@@ -167,14 +168,38 @@ def _get_image_kwargs(
     }
 
 
-def _build_image_response(response: httpx.Response) -> Image:
+def _build_file_content_response(response: httpx.Response) -> File:
     if response.status_code == HTTPStatus.OK:
         x_headers = build_x_headers(response)
-        return Image(x_headers=x_headers, content=base64.b64encode(response.content).decode())
+        return File(x_headers=x_headers, content=base64.b64encode(response.content).decode())
     elif response.status_code == HTTPStatus.UNAUTHORIZED:
         raise AuthenticationError(response.url, response.status_code, response.content, response.headers)
     else:
         raise ResponseError(response.url, response.status_code, response.content, response.headers)
+
+
+def get_file_content_sync(
+    client: httpx.Client,
+    *,
+    file_id: str,
+    access_token: Optional[str] = None,
+) -> File:
+    """Return file content in base64 encoding."""
+    kwargs = _get_file_content_kwargs(access_token=access_token, file_id=file_id)
+    response = client.request(**kwargs)
+    return _build_file_content_response(response)
+
+
+async def get_file_content_async(
+    client: httpx.AsyncClient,
+    *,
+    file_id: str,
+    access_token: Optional[str] = None,
+) -> File:
+    """Return file content in base64 encoding."""
+    kwargs = _get_file_content_kwargs(access_token=access_token, file_id=file_id)
+    response = await client.request(**kwargs)
+    return _build_file_content_response(response)
 
 
 def get_image_sync(
@@ -182,11 +207,14 @@ def get_image_sync(
     *,
     file_id: str,
     access_token: Optional[str] = None,
-) -> Image:
-    """Return an image in base64 encoding."""
-    kwargs = _get_image_kwargs(access_token=access_token, file_id=file_id)
-    response = client.request(**kwargs)
-    return _build_image_response(response)
+) -> File:
+    """Use `get_file_content_sync`; this alias is deprecated."""
+    warnings.warn(
+        "Function 'get_image_sync' is deprecated, use 'get_file_content_sync'",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return get_file_content_sync(client, file_id=file_id, access_token=access_token)
 
 
 async def get_image_async(
@@ -194,8 +222,11 @@ async def get_image_async(
     *,
     file_id: str,
     access_token: Optional[str] = None,
-) -> Image:
-    """Return an image in base64 encoding."""
-    kwargs = _get_image_kwargs(access_token=access_token, file_id=file_id)
-    response = await client.request(**kwargs)
-    return _build_image_response(response)
+) -> File:
+    """Use `get_file_content_async`; this alias is deprecated."""
+    warnings.warn(
+        "Function 'get_image_async' is deprecated, use 'get_file_content_async'",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return await get_file_content_async(client, file_id=file_id, access_token=access_token)

--- a/src/gigachat/client.py
+++ b/src/gigachat/client.py
@@ -19,12 +19,13 @@ from typing import (
 import httpx
 from typing_extensions import Self
 
-from gigachat._types import FileTypes
-from gigachat.api import auth, chat, embeddings, files, models, tools
+from gigachat._types import FileContent, FileTypes
+from gigachat.api import auth, batches, chat, embeddings, files, models, tools
 from gigachat.assistants import AssistantsAsyncClient, AssistantsSyncClient
 from gigachat.authentication import _awith_auth, _awith_auth_stream, _with_auth, _with_auth_stream
 from gigachat.context import authorization_cvar
 from gigachat.models.auth import AccessToken, Token
+from gigachat.models.batches import Batch, Batches
 from gigachat.models.chat import (
     Chat,
     ChatCompletion,
@@ -354,6 +355,18 @@ class GigaChatSyncClient(_BaseClient):
 
     @_with_retry
     @_with_auth
+    def create_batch(self, file: FileContent, method: Literal["chat_completions", "embedder"]) -> Batch:
+        """Create a batch task for asynchronous processing."""
+        return batches.create_batch_sync(self._client, file=file, method=method, access_token=self.token)
+
+    @_with_retry
+    @_with_auth
+    def get_batches(self, batch_id: Optional[str] = None) -> Batches:
+        """Return batch tasks or a specific batch task."""
+        return batches.get_batches_sync(self._client, batch_id=batch_id, access_token=self.token)
+
+    @_with_retry
+    @_with_auth
     def get_models(self) -> Models:
         """Return a list of available models."""
         return models.get_models_sync(self._client, access_token=self.token)
@@ -600,6 +613,18 @@ class GigaChatAsyncClient(_BaseClient):
         """Return embeddings."""
 
         return await embeddings.embeddings_async(self._aclient, access_token=self.token, input_=texts, model=model)
+
+    @_awith_retry
+    @_awith_auth
+    async def acreate_batch(self, file: FileContent, method: Literal["chat_completions", "embedder"]) -> Batch:
+        """Create a batch task for asynchronous processing."""
+        return await batches.create_batch_async(self._aclient, file=file, method=method, access_token=self.token)
+
+    @_awith_retry
+    @_awith_auth
+    async def aget_batches(self, batch_id: Optional[str] = None) -> Batches:
+        """Return batch tasks or a specific batch task."""
+        return await batches.get_batches_async(self._aclient, batch_id=batch_id, access_token=self.token)
 
     @_awith_retry
     @_awith_auth

--- a/src/gigachat/client.py
+++ b/src/gigachat/client.py
@@ -3,6 +3,7 @@ import logging
 import ssl
 import threading
 import time
+import warnings
 from typing import (
     Any,
     AsyncIterator,
@@ -34,7 +35,7 @@ from gigachat.models.chat import (
     MessagesRole,
 )
 from gigachat.models.embeddings import Embeddings
-from gigachat.models.files import DeletedFile, Image, UploadedFile, UploadedFiles
+from gigachat.models.files import DeletedFile, File, UploadedFile, UploadedFiles
 from gigachat.models.models import Model, Models
 from gigachat.models.tools import AICheckResult, Balance, OpenApiFunctions, TokensCount
 from gigachat.retry import _awith_retry, _awith_retry_stream, _with_retry, _with_retry_stream
@@ -379,9 +380,20 @@ class GigaChatSyncClient(_BaseClient):
 
     @_with_retry
     @_with_auth
-    def get_image(self, file_id: str) -> Image:
-        """Return an image in base64 encoding."""
-        return files.get_image_sync(self._client, file_id=file_id, access_token=self.token)
+    def get_file_content(self, file_id: str) -> File:
+        """Return file content in base64 encoding."""
+        return files.get_file_content_sync(self._client, file_id=file_id, access_token=self.token)
+
+    @_with_retry
+    @_with_auth
+    def get_image(self, file_id: str) -> File:
+        """Use `get_file_content`; this alias is deprecated."""
+        warnings.warn(
+            "Method 'get_image' is deprecated, use 'get_file_content'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_file_content(file_id=file_id)
 
     @_with_retry
     @_with_auth
@@ -635,10 +647,20 @@ class GigaChatAsyncClient(_BaseClient):
 
     @_awith_retry
     @_awith_auth
-    async def aget_image(self, file_id: str) -> Image:
-        """Return an image in base64 encoding."""
+    async def aget_file_content(self, file_id: str) -> File:
+        """Return file content in base64 encoding."""
+        return await files.get_file_content_async(self._aclient, file_id=file_id, access_token=self.token)
 
-        return await files.get_image_async(self._aclient, file_id=file_id, access_token=self.token)
+    @_awith_retry
+    @_awith_auth
+    async def aget_image(self, file_id: str) -> File:
+        """Use `aget_file_content`; this alias is deprecated."""
+        warnings.warn(
+            "Method 'aget_image' is deprecated, use 'aget_file_content'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return await self.aget_file_content(file_id=file_id)
 
     @_awith_retry
     @_awith_auth

--- a/src/gigachat/models/__init__.py
+++ b/src/gigachat/models/__init__.py
@@ -9,6 +9,7 @@ from gigachat.models.assistants import (
 )
 from gigachat.models.auth import AccessToken, Token
 from gigachat.models.base import APIResponse
+from gigachat.models.batches import Batch, Batches, BatchMethod, BatchRequestCounts, BatchStatus
 from gigachat.models.chat import (
     Chat,
     ChatCompletion,
@@ -53,6 +54,11 @@ __all__ = (
     "AssistantFileDelete",
     "Assistants",
     "Balance",
+    "Batch",
+    "Batches",
+    "BatchMethod",
+    "BatchRequestCounts",
+    "BatchStatus",
     "Chat",
     "ChatCompletion",
     "ChatCompletionChunk",

--- a/src/gigachat/models/batches.py
+++ b/src/gigachat/models/batches.py
@@ -1,0 +1,47 @@
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from gigachat.models.base import APIResponse
+
+
+class BatchMethod(str, Enum):
+    """Batch execution method."""
+
+    CHAT_COMPLETIONS = "chat_completions"
+    EMBEDDER = "embedder"
+
+
+class BatchStatus(str, Enum):
+    """Batch processing status."""
+
+    CREATED = "created"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+
+
+class BatchRequestCounts(BaseModel):
+    """Batch request counters."""
+
+    total: int = Field(default=0, description="Total number of requests in the batch.")
+    completed: Optional[int] = Field(default=None, description="Number of completed requests.")
+    failed: Optional[int] = Field(default=None, description="Number of failed requests.")
+
+
+class Batch(APIResponse):
+    """Batch task metadata."""
+
+    id_: str = Field(alias="id", description="Batch task identifier.")
+    method: BatchMethod = Field(description="Method used to process tasks in the batch.")
+    request_counts: BatchRequestCounts = Field(description="Request counters for the batch.")
+    status: BatchStatus = Field(description="Current batch task status.")
+    output_file_id: Optional[str] = Field(default=None, description="Identifier of the output file with results.")
+    created_at: int = Field(description="Creation timestamp (Unix time).")
+    updated_at: int = Field(description="Last update timestamp (Unix time).")
+
+
+class Batches(APIResponse):
+    """List of batch tasks."""
+
+    batches: List[Batch] = Field(description="List of batch tasks.")

--- a/src/gigachat/models/files.py
+++ b/src/gigachat/models/files.py
@@ -30,7 +30,12 @@ class DeletedFile(APIResponse):
     deleted: bool = Field(description="Deletion status. True if deleted.")
 
 
-class Image(APIResponse):
-    """Image content."""
+class File(APIResponse):
+    """Base64-encoded file content."""
 
+    content: str = Field(description="Base64 encoded file data.")
+
+
+class Image(APIResponse):
+    """DEPRECATED: Base64-encoded Image content"""
     content: str = Field(description="Base64 encoded image data.")

--- a/src/gigachat/models/files.py
+++ b/src/gigachat/models/files.py
@@ -38,4 +38,5 @@ class File(APIResponse):
 
 class Image(APIResponse):
     """DEPRECATED: Base64-encoded Image content"""
+
     content: str = Field(description="Base64 encoded image data.")

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -55,6 +55,8 @@ BALANCE_URL = f"{BASE_URL}/balance"
 CONVERT_FUNCTIONS_URL = f"{BASE_URL}/functions/convert"
 AI_CHECK_URL = f"{BASE_URL}/ai/check"
 EMBEDDINGS_URL = f"{BASE_URL}/embeddings"
+BATCHES_URL = f"{BASE_URL}/batches"
+BATCH_BY_ID_URL = f"{BASE_URL}/batches?batch_id=batch_1"
 GET_ASSISTANTS_URL = f"{BASE_URL}/assistants"
 POST_ASSISTANTS_URL = f"{BASE_URL}/assistants"
 POST_ASSISTANT_MODIFY_URL = f"{BASE_URL}/assistants/modify"
@@ -85,6 +87,8 @@ POST_ASSISTANT_FILES_DELETE = get_json("assistants/post_assistant_files_delete.j
 POST_ASSISTANT_DELETE = get_json("assistants/post_assistant_delete.json")
 
 EMBEDDINGS = get_json("embeddings.json")
+BATCH = get_json("batch.json")
+BATCHES = get_json("batches.json")
 
 FILES = get_json("post_files.json")
 GET_FILE = get_json("get_file.json")

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -89,6 +89,7 @@ POST_ASSISTANT_DELETE = get_json("assistants/post_assistant_delete.json")
 EMBEDDINGS = get_json("embeddings.json")
 BATCH = get_json("batch.json")
 BATCHES = get_json("batches.json")
+BATCHES_LIST = BATCHES["batches"]
 
 FILES = get_json("post_files.json")
 GET_FILE = get_json("get_file.json")

--- a/tests/data/batch.json
+++ b/tests/data/batch.json
@@ -1,0 +1,10 @@
+{
+  "id": "batch_1",
+  "method": "chat_completions",
+  "request_counts": {
+    "total": 3
+  },
+  "status": "created",
+  "created_at": 1726478395,
+  "updated_at": 1726478395
+}

--- a/tests/data/batches.json
+++ b/tests/data/batches.json
@@ -1,0 +1,17 @@
+{
+  "batches": [
+    {
+      "id": "batch_1",
+      "method": "chat_completions",
+      "request_counts": {
+        "total": 3,
+        "completed": 2,
+        "failed": 1
+      },
+      "status": "completed",
+      "output_file_id": "file_123",
+      "created_at": 1726478395,
+      "updated_at": 1726478474
+    }
+  ]
+}

--- a/tests/unit/gigachat/api/test_batches.py
+++ b/tests/unit/gigachat/api/test_batches.py
@@ -1,0 +1,44 @@
+import httpx
+from pytest_httpx import HTTPXMock
+
+from gigachat.api.batches import create_batch_async, create_batch_sync, get_batches_async, get_batches_sync
+from gigachat.models.batches import Batch, Batches
+from tests.constants import BASE_URL, BATCH, BATCH_BY_ID_URL, BATCHES, BATCHES_URL
+
+
+def test_create_batch_sync(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=f"{BATCHES_URL}?method=chat_completions", json=BATCH)
+
+    with httpx.Client(base_url=BASE_URL) as client:
+        response = create_batch_sync(client, file='{"id":"1","request":{}}', method="chat_completions")
+
+    assert isinstance(response, Batch)
+
+
+async def test_create_batch_async(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=f"{BATCHES_URL}?method=embedder", json=BATCH)
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        response = await create_batch_async(client, file=b'{"id":"1","request":{}}', method="embedder")
+
+    assert isinstance(response, Batch)
+
+
+def test_get_batches_sync(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=BATCHES_URL, json=BATCHES)
+
+    with httpx.Client(base_url=BASE_URL) as client:
+        response = get_batches_sync(client)
+
+    assert isinstance(response, Batches)
+    assert len(response.batches) == 1
+
+
+async def test_get_batches_async(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=BATCH_BY_ID_URL, json=BATCHES)
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        response = await get_batches_async(client, batch_id="batch_1")
+
+    assert isinstance(response, Batches)
+    assert response.batches[0].id_ == "batch_1"

--- a/tests/unit/gigachat/api/test_batches.py
+++ b/tests/unit/gigachat/api/test_batches.py
@@ -3,7 +3,7 @@ from pytest_httpx import HTTPXMock
 
 from gigachat.api.batches import create_batch_async, create_batch_sync, get_batches_async, get_batches_sync
 from gigachat.models.batches import Batch, Batches
-from tests.constants import BASE_URL, BATCH, BATCH_BY_ID_URL, BATCHES, BATCHES_URL
+from tests.constants import BASE_URL, BATCH, BATCH_BY_ID_URL, BATCHES, BATCHES_LIST, BATCHES_URL
 
 
 def test_create_batch_sync(httpx_mock: HTTPXMock) -> None:
@@ -25,7 +25,7 @@ async def test_create_batch_async(httpx_mock: HTTPXMock) -> None:
 
 
 def test_get_batches_sync(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(url=BATCHES_URL, json=BATCHES)
+    httpx_mock.add_response(url=BATCHES_URL, json=BATCHES_LIST)
 
     with httpx.Client(base_url=BASE_URL) as client:
         response = get_batches_sync(client)
@@ -42,3 +42,13 @@ async def test_get_batches_async(httpx_mock: HTTPXMock) -> None:
 
     assert isinstance(response, Batches)
     assert response.batches[0].id_ == "batch_1"
+
+
+def test_get_batches_sync_single_batch_payload(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=BATCH_BY_ID_URL, json=BATCHES_LIST[0])
+
+    with httpx.Client(base_url=BASE_URL) as client:
+        response = get_batches_sync(client, batch_id="batch_1")
+
+    assert isinstance(response, Batches)
+    assert len(response.batches) == 1

--- a/tests/unit/gigachat/api/test_files.py
+++ b/tests/unit/gigachat/api/test_files.py
@@ -15,7 +15,7 @@ from gigachat.api.files import (
     upload_file_async,
     upload_file_sync,
 )
-from gigachat.models.files import DeletedFile, Image, UploadedFile, UploadedFiles
+from gigachat.models.files import DeletedFile, File, UploadedFile, UploadedFiles
 from tests.constants import (
     BASE_URL,
     FILE,
@@ -110,7 +110,7 @@ def test_get_image_sync(httpx_mock: HTTPXMock) -> None:
     with httpx.Client(base_url=BASE_URL) as client:
         response = get_file_content_sync(client, file_id="img_file")
 
-    assert isinstance(response, Image)
+    assert isinstance(response, File)
     assert response.content
 
 
@@ -120,7 +120,7 @@ async def test_get_image_async(httpx_mock: HTTPXMock) -> None:
     async with httpx.AsyncClient(base_url=BASE_URL) as client:
         response = await get_file_content_async(client, file_id="img_file")
 
-    assert isinstance(response, Image)
+    assert isinstance(response, File)
     assert response.content
 
 
@@ -130,7 +130,7 @@ def test_get_image_sync_deprecated(httpx_mock: HTTPXMock) -> None:
     with httpx.Client(base_url=BASE_URL) as client:
         response = get_image_sync(client, file_id="img_file")
 
-    assert isinstance(response, Image)
+    assert isinstance(response, File)
     assert response.content
 
 
@@ -140,5 +140,5 @@ async def test_get_image_async_deprecated(httpx_mock: HTTPXMock) -> None:
     async with httpx.AsyncClient(base_url=BASE_URL) as client:
         response = await get_image_async(client, file_id="img_file")
 
-    assert isinstance(response, Image)
+    assert isinstance(response, File)
     assert response.content

--- a/tests/unit/gigachat/api/test_files.py
+++ b/tests/unit/gigachat/api/test_files.py
@@ -5,6 +5,8 @@ from gigachat.api.files import (
     delete_file_async,
     delete_file_sync,
     get_file_async,
+    get_file_content_async,
+    get_file_content_sync,
     get_file_sync,
     get_files_async,
     get_files_sync,
@@ -106,13 +108,33 @@ def test_get_image_sync(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(url=IMAGE_URL, content=IMAGE)
 
     with httpx.Client(base_url=BASE_URL) as client:
-        response = get_image_sync(client, file_id="img_file")
+        response = get_file_content_sync(client, file_id="img_file")
 
     assert isinstance(response, Image)
     assert response.content
 
 
 async def test_get_image_async(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=IMAGE_URL, content=IMAGE)
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        response = await get_file_content_async(client, file_id="img_file")
+
+    assert isinstance(response, Image)
+    assert response.content
+
+
+def test_get_image_sync_deprecated(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=IMAGE_URL, content=IMAGE)
+
+    with httpx.Client(base_url=BASE_URL) as client:
+        response = get_image_sync(client, file_id="img_file")
+
+    assert isinstance(response, Image)
+    assert response.content
+
+
+async def test_get_image_async_deprecated(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(url=IMAGE_URL, content=IMAGE)
 
     async with httpx.AsyncClient(base_url=BASE_URL) as client:

--- a/tests/unit/gigachat/test_client_batches.py
+++ b/tests/unit/gigachat/test_client_batches.py
@@ -2,7 +2,7 @@ from pytest_httpx import HTTPXMock
 
 from gigachat.client import GigaChatAsyncClient, GigaChatSyncClient
 from gigachat.models.batches import Batch, Batches
-from tests.constants import BASE_URL, BATCH, BATCH_BY_ID_URL, BATCHES, BATCHES_URL
+from tests.constants import BASE_URL, BATCH, BATCH_BY_ID_URL, BATCHES, BATCHES_LIST, BATCHES_URL
 
 
 def test_create_batch(httpx_mock: HTTPXMock) -> None:
@@ -34,7 +34,7 @@ async def test_acreate_batch(httpx_mock: HTTPXMock) -> None:
 
 
 async def test_aget_batches(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(url=BATCHES_URL, json=BATCHES)
+    httpx_mock.add_response(url=BATCHES_URL, json=BATCHES_LIST)
 
     async with GigaChatAsyncClient(base_url=BASE_URL) as client:
         response = await client.aget_batches()

--- a/tests/unit/gigachat/test_client_batches.py
+++ b/tests/unit/gigachat/test_client_batches.py
@@ -1,0 +1,43 @@
+from pytest_httpx import HTTPXMock
+
+from gigachat.client import GigaChatAsyncClient, GigaChatSyncClient
+from gigachat.models.batches import Batch, Batches
+from tests.constants import BASE_URL, BATCH, BATCH_BY_ID_URL, BATCHES, BATCHES_URL
+
+
+def test_create_batch(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=f"{BATCHES_URL}?method=chat_completions", json=BATCH)
+
+    with GigaChatSyncClient(base_url=BASE_URL) as client:
+        response = client.create_batch(file='{"id":"1","request":{}}', method="chat_completions")
+
+    assert isinstance(response, Batch)
+
+
+def test_get_batches(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=BATCH_BY_ID_URL, json=BATCHES)
+
+    with GigaChatSyncClient(base_url=BASE_URL) as client:
+        response = client.get_batches(batch_id="batch_1")
+
+    assert isinstance(response, Batches)
+    assert response.batches[0].id_ == "batch_1"
+
+
+async def test_acreate_batch(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=f"{BATCHES_URL}?method=embedder", json=BATCH)
+
+    async with GigaChatAsyncClient(base_url=BASE_URL) as client:
+        response = await client.acreate_batch(file=b'{"id":"1","request":{}}', method="embedder")
+
+    assert isinstance(response, Batch)
+
+
+async def test_aget_batches(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=BATCHES_URL, json=BATCHES)
+
+    async with GigaChatAsyncClient(base_url=BASE_URL) as client:
+        response = await client.aget_batches()
+
+    assert isinstance(response, Batches)
+    assert len(response.batches) == 1

--- a/tests/unit/gigachat/test_client_files.py
+++ b/tests/unit/gigachat/test_client_files.py
@@ -1,7 +1,8 @@
 from pytest_httpx import HTTPXMock
 
 from gigachat.client import GigaChatAsyncClient, GigaChatSyncClient
-from gigachat.models import DeletedFile, Image, UploadedFile, UploadedFiles
+from gigachat.models import DeletedFile, UploadedFile, UploadedFiles
+from gigachat.models.files import File
 from tests.constants import (
     BASE_URL,
     FILE,
@@ -57,7 +58,7 @@ def test_get_image(httpx_mock: HTTPXMock) -> None:
     with GigaChatSyncClient(base_url=BASE_URL, model="model") as client:
         response = client.get_file_content(file_id="img_file")
 
-    assert isinstance(response, Image)
+    assert isinstance(response, File)
 
 
 async def test_aupload_file(httpx_mock: HTTPXMock) -> None:
@@ -99,7 +100,7 @@ async def test_aget_image(httpx_mock: HTTPXMock) -> None:
     async with GigaChatAsyncClient(base_url=BASE_URL, model="model") as client:
         response = await client.aget_file_content(file_id="img_file")
 
-    assert isinstance(response, Image)
+    assert isinstance(response, File)
 
 
 def test_get_image_deprecated(httpx_mock: HTTPXMock) -> None:
@@ -107,7 +108,7 @@ def test_get_image_deprecated(httpx_mock: HTTPXMock) -> None:
     with GigaChatSyncClient(base_url=BASE_URL, model="model") as client:
         response = client.get_image(file_id="img_file")
 
-    assert isinstance(response, Image)
+    assert isinstance(response, File)
 
 
 async def test_aget_image_deprecated(httpx_mock: HTTPXMock) -> None:
@@ -115,4 +116,4 @@ async def test_aget_image_deprecated(httpx_mock: HTTPXMock) -> None:
     async with GigaChatAsyncClient(base_url=BASE_URL, model="model") as client:
         response = await client.aget_image(file_id="img_file")
 
-    assert isinstance(response, Image)
+    assert isinstance(response, File)

--- a/tests/unit/gigachat/test_client_files.py
+++ b/tests/unit/gigachat/test_client_files.py
@@ -55,7 +55,7 @@ def test_delete_file(httpx_mock: HTTPXMock) -> None:
 def test_get_image(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(url=IMAGE_URL, content=IMAGE)
     with GigaChatSyncClient(base_url=BASE_URL, model="model") as client:
-        response = client.get_image(file_id="img_file")
+        response = client.get_file_content(file_id="img_file")
 
     assert isinstance(response, Image)
 
@@ -95,6 +95,22 @@ async def test_adelete_file(httpx_mock: HTTPXMock) -> None:
 
 
 async def test_aget_image(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=IMAGE_URL, content=IMAGE)
+    async with GigaChatAsyncClient(base_url=BASE_URL, model="model") as client:
+        response = await client.aget_file_content(file_id="img_file")
+
+    assert isinstance(response, Image)
+
+
+def test_get_image_deprecated(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=IMAGE_URL, content=IMAGE)
+    with GigaChatSyncClient(base_url=BASE_URL, model="model") as client:
+        response = client.get_image(file_id="img_file")
+
+    assert isinstance(response, Image)
+
+
+async def test_aget_image_deprecated(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(url=IMAGE_URL, content=IMAGE)
     async with GigaChatAsyncClient(base_url=BASE_URL, model="model") as client:
         response = await client.aget_image(file_id="img_file")

--- a/tests/unit/gigachat/test_init.py
+++ b/tests/unit/gigachat/test_init.py
@@ -1,0 +1,13 @@
+import re
+from pathlib import Path
+
+import gigachat
+
+
+def test_version_matches_project_metadata() -> None:
+    pyproject = Path(__file__).resolve().parents[3] / "pyproject.toml"
+    content = pyproject.read_text(encoding="utf-8")
+    match = re.search(r'^version = "([^"]+)"$', content, re.MULTILINE)
+
+    assert match is not None
+    assert gigachat.__version__ == match.group(1)

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
## Description

Add support for the GigaChat batches API, including client methods, batch models, and example usage. This PR also introduces generic file content retrieval, keeps `get_image` as a deprecated alias for backward compatibility, and exposes the package version via `gigachat.__version__`.

## Motivation

The SDK needs first-class support for asynchronous batch processing so users can submit JSONL workloads, track batch execution, and download result files through the Python client. While adding that flow, the file-download API was generalized beyond images to better match batch output handling.

Closes #<!-- issue number -->

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD or tooling change

## Changes Made

- Add `create_batch` / `get_batches` sync and async client methods plus new batch API and Pydantic models
- Add `get_file_content` / `aget_file_content` and deprecate `get_image` aliases without breaking existing callers
- Add batching fixtures, unit tests, a batching example notebook, and export `gigachat.__version__`

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] All existing tests pass locally

### Manual Testing

Targeted checks run in this environment:

```bash
uv run pytest tests/unit/gigachat/test_init.py
uv run ruff check src/gigachat/api/batches.py src/gigachat/models/batches.py src/gigachat/client.py src/gigachat/models/__init__.py src/gigachat/api/__init__.py src/gigachat/__init__.py tests/unit/gigachat/api/test_batches.py tests/unit/gigachat/test_client_batches.py tests/constants.py
