### PR TITLE
Feature/aiohttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This library is part of [GigaChain](https://github.com/ai-forever/gigachain) and
   - [Basic Chat](#basic-chat)
   - [Streaming](#streaming)
   - [Async](#async)
+  - [Async With `aiohttp`](#async-with-aiohttp)
   - [Embeddings](#embeddings)
   - [Function Calling](#function-calling)
   - [Structured Output (JSON Schema)](#structured-output-json-schema)
@@ -52,6 +53,12 @@ This library is part of [GigaChain](https://github.com/ai-forever/gigachain) and
 
 ```bash
 pip install gigachat
+```
+
+To use `aiohttp` as the async HTTP backend for async clients:
+
+```bash
+pip install gigachat[aiohttp]
 ```
 
 **Requirements:** Python 3.8 — 3.13
@@ -122,6 +129,47 @@ async def main():
 
 asyncio.run(main())
 ```
+
+### Async With `aiohttp`
+
+By default, async requests use `httpx`. For higher-concurrency workloads you can switch the async backend to `aiohttp`.
+This option affects async clients only and does not change the synchronous client.
+
+First install the extra:
+
+```bash
+pip install gigachat[aiohttp]
+```
+
+Then pass `DefaultAioHttpClient()` to `GigaChat(...)`:
+
+```python
+import asyncio
+
+from gigachat import DefaultAioHttpClient, GigaChat
+
+
+async def main() -> None:
+    async with GigaChat(
+        http_client=DefaultAioHttpClient(),
+        max_connections=100,
+    ) as client:
+        response = await client.achat("Say this is a test")
+        print(response.choices[0].message.content)
+
+        print("Streaming response:")
+        async for chunk in client.astream("Write one sentence about aiohttp"):
+            print(chunk.choices[0].delta.content, end="", flush=True)
+        print()
+
+
+asyncio.run(main())
+```
+
+`gigachat[aiohttp]` installs the appropriate dependency for your Python version:
+
+- Python 3.8: `aiohttp`
+- Python 3.9+: `httpx-aiohttp`
 
 ### Embeddings
 
@@ -293,6 +341,7 @@ See the [examples/](https://github.com/ai-forever/gigachat/tree/main/examples/) 
 | `key_file` | `str` | `None` | Path to client private key (for mTLS) |
 | `key_file_password` | `str` | `None` | Password for encrypted private key |
 | `timeout` | `float` | `30.0` | Request timeout in seconds |
+| `http_client` | `AsyncHttpClientFactory` | `None` | Custom async HTTP backend factory (async clients only) |
 | `max_connections` | `int` | `None` | Maximum concurrent connections |
 | `max_retries` | `int` | `0` | Maximum retry attempts for transient errors |
 | `retry_backoff_factor` | `float` | `0.5` | Exponential backoff multiplier |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ dependencies = [
     "httpx>=0.24,<1",
 ]
 
+[project.optional-dependencies]
+aiohttp = [
+    "aiohttp>=3.9,<4 ; python_version == '3.8'",
+    "httpx-aiohttp>=0.1.8,<1 ; python_version >= '3.9'",
+]
+
 [project.urls]
 Repository = "https://github.com/ai-forever/gigachat"
 

--- a/src/gigachat/__init__.py
+++ b/src/gigachat/__init__.py
@@ -18,6 +18,7 @@ from gigachat.exceptions import (
     ResponseError,
     ServerError,
 )
+from gigachat.http_client import DefaultAioHttpClient
 from gigachat.models import (
     Batch,
     Batches,
@@ -47,6 +48,7 @@ __all__ = [
     "GigaChat",
     "GigaChatSyncClient",
     "GigaChatAsyncClient",
+    "DefaultAioHttpClient",
     "GigaChatException",
     "ResponseError",
     "AuthenticationError",

--- a/src/gigachat/api/assistants.py
+++ b/src/gigachat/api/assistants.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from gigachat.api.utils import build_headers, execute_request_async, execute_request_sync
+from gigachat.http_client import AsyncHttpClient
 from gigachat.models.assistants import (
     Assistant,
     AssistantDelete,
@@ -41,7 +42,7 @@ def get_assistants_sync(
 
 
 async def get_assistants_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     assistant_id: Optional[str] = None,
     access_token: Optional[str] = None,
@@ -109,7 +110,7 @@ def create_assistant_sync(
 
 
 async def create_assistant_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     model: str,
     name: str,
@@ -193,7 +194,7 @@ def modify_assistant_sync(
 
 
 async def modify_assistant_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     assistant_id: str,
     name: Optional[str] = None,
@@ -247,7 +248,7 @@ def delete_assistant_sync(
 
 
 async def delete_assistant_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     assistant_id: str,
     access_token: Optional[str] = None,
@@ -289,7 +290,7 @@ def delete_assistant_file_sync(
 
 
 async def delete_assistant_file_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     assistant_id: str,
     file_id: str,

--- a/src/gigachat/api/auth.py
+++ b/src/gigachat/api/auth.py
@@ -15,6 +15,7 @@ from gigachat.api.utils import (
     execute_request_async,
     execute_request_sync,
 )
+from gigachat.http_client import AsyncHttpClient
 from gigachat.models.auth import AccessToken, Token
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,7 @@ def auth_sync(client: httpx.Client, *, url: str, credentials: str, scope: str) -
     return _build_auth_response(response)
 
 
-async def auth_async(client: httpx.AsyncClient, *, url: str, credentials: str, scope: str) -> AccessToken:
+async def auth_async(client: AsyncHttpClient, *, url: str, credentials: str, scope: str) -> AccessToken:
     """Return an access token."""
     _validate_credentials(credentials)
     kwargs = _get_auth_kwargs(url=url, credentials=credentials, scope=scope)
@@ -99,7 +100,7 @@ def token_sync(
 
 
 async def token_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     user: str,
     password: str,

--- a/src/gigachat/api/batches.py
+++ b/src/gigachat/api/batches.py
@@ -10,6 +10,7 @@ from gigachat.api.utils import (
     execute_request_async,
     execute_request_sync,
 )
+from gigachat.http_client import AsyncHttpClient
 from gigachat.models.batches import Batch, Batches
 
 
@@ -56,7 +57,7 @@ def create_batch_sync(
 
 
 async def create_batch_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     file: FileContent,
     method: Literal["chat_completions", "embedder"],
@@ -115,7 +116,7 @@ def get_batches_sync(
 
 
 async def get_batches_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     batch_id: Optional[str] = None,
     access_token: Optional[str] = None,

--- a/src/gigachat/api/chat.py
+++ b/src/gigachat/api/chat.py
@@ -12,6 +12,7 @@ from gigachat.api.utils import (
     execute_stream_sync,
 )
 from gigachat.context import chat_url_cvar
+from gigachat.http_client import AsyncHttpClient
 from gigachat.models.chat import Chat, ChatCompletion, ChatCompletionChunk
 
 
@@ -52,7 +53,7 @@ def chat_sync(
 
 
 async def chat_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     chat: Chat,
     access_token: Optional[str] = None,
@@ -101,7 +102,7 @@ def stream_sync(
 
 
 def stream_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     chat: Chat,
     access_token: Optional[str] = None,

--- a/src/gigachat/api/embeddings.py
+++ b/src/gigachat/api/embeddings.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 
 from gigachat.api.utils import build_headers, execute_request_async, execute_request_sync
+from gigachat.http_client import AsyncHttpClient
 from gigachat.models.embeddings import Embeddings
 
 
@@ -37,7 +38,7 @@ def embeddings_sync(
 
 
 async def embeddings_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     input_: List[str],
     model: str,

--- a/src/gigachat/api/files.py
+++ b/src/gigachat/api/files.py
@@ -8,6 +8,7 @@ import httpx
 from gigachat._types import FileTypes
 from gigachat.api.utils import build_headers, build_x_headers, execute_request_async, execute_request_sync
 from gigachat.exceptions import AuthenticationError, ResponseError
+from gigachat.http_client import AsyncHttpClient
 from gigachat.models.files import DeletedFile, File, UploadedFile, UploadedFiles
 
 
@@ -36,7 +37,7 @@ def get_file_sync(
 
 
 async def get_file_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     file: str,
     access_token: Optional[str] = None,
@@ -69,7 +70,7 @@ def get_files_sync(
 
 
 async def get_files_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     access_token: Optional[str] = None,
 ) -> UploadedFiles:
@@ -107,7 +108,7 @@ def upload_file_sync(
 
 
 async def upload_file_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     file: FileTypes,
     purpose: Literal["general", "assistant"] = "general",
@@ -144,7 +145,7 @@ def delete_file_sync(
 
 
 async def delete_file_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     file: str,
     access_token: Optional[str] = None,
@@ -191,7 +192,7 @@ def get_file_content_sync(
 
 
 async def get_file_content_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     file_id: str,
     access_token: Optional[str] = None,
@@ -218,7 +219,7 @@ def get_image_sync(
 
 
 async def get_image_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     file_id: str,
     access_token: Optional[str] = None,

--- a/src/gigachat/api/models.py
+++ b/src/gigachat/api/models.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 import httpx
 
 from gigachat.api.utils import build_headers, execute_request_async, execute_request_sync
+from gigachat.http_client import AsyncHttpClient
 from gigachat.models.models import Model, Models
 
 
@@ -30,7 +31,7 @@ def get_models_sync(
 
 
 async def get_models_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     access_token: Optional[str] = None,
 ) -> Models:
@@ -65,7 +66,7 @@ def get_model_sync(
 
 
 async def get_model_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     model: str,
     access_token: Optional[str] = None,

--- a/src/gigachat/api/threads.py
+++ b/src/gigachat/api/threads.py
@@ -11,6 +11,7 @@ from gigachat.api.utils import (
     execute_stream_sync,
 )
 from gigachat.exceptions import AuthenticationError, ResponseError
+from gigachat.http_client import AsyncHttpClient
 from gigachat.models.chat import Messages
 from gigachat.models.threads import (
     Thread,
@@ -67,7 +68,7 @@ def get_threads_sync(
 
 
 async def get_threads_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     assistants_ids: Optional[List[str]] = None,
     limit: Optional[int] = None,
@@ -105,7 +106,7 @@ def post_thread_sync(
 
 
 async def post_thread_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     access_token: Optional[str] = None,
 ) -> Thread:
@@ -142,7 +143,7 @@ def retrieve_threads_sync(
 
 
 async def retrieve_threads_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     threads_ids: List[str],
     access_token: Optional[str] = None,
@@ -190,7 +191,7 @@ def delete_thread_sync(
 
 
 async def delete_thread_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     thread_id: str,
     access_token: Optional[str] = None,
@@ -227,7 +228,7 @@ def get_thread_run_sync(
 
 
 async def get_thread_run_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     thread_id: str,
     access_token: Optional[str] = None,
@@ -272,7 +273,7 @@ def get_thread_messages_sync(
 
 
 async def get_thread_messages_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     thread_id: str,
     limit: Optional[int] = None,
@@ -322,7 +323,7 @@ def run_thread_sync(
 
 
 async def run_thread_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     thread_id: str,
     assistant_id: Optional[str] = None,
@@ -380,7 +381,7 @@ def run_thread_stream_sync(
 
 
 def run_thread_stream_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     thread_id: str,
     assistant_id: Optional[str] = None,
@@ -442,7 +443,7 @@ def add_thread_messages_sync(
 
 
 async def add_thread_messages_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     messages: List[Messages],
     model: Optional[str] = None,
@@ -515,7 +516,7 @@ def run_thread_messages_sync(
 
 
 async def run_thread_messages_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     messages: List[Messages],
     thread_id: Optional[str] = None,
@@ -576,7 +577,7 @@ def rerun_thread_messages_sync(
 
 
 async def rerun_thread_messages_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     thread_id: str,
     thread_options: Optional[ThreadRunOptions] = None,
@@ -650,7 +651,7 @@ def run_thread_messages_stream_sync(
 
 
 def run_thread_messages_stream_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     messages: List[Messages],
     thread_id: Optional[str] = None,
@@ -718,7 +719,7 @@ def rerun_thread_messages_stream_sync(
 
 
 def rerun_thread_messages_stream_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     thread_id: str,
     thread_options: Optional[ThreadRunOptions] = None,

--- a/src/gigachat/api/tools.py
+++ b/src/gigachat/api/tools.py
@@ -6,6 +6,7 @@ import httpx
 
 from gigachat.api.utils import build_headers, execute_request_async, execute_request_sync
 from gigachat.exceptions import AuthenticationError, ResponseError
+from gigachat.http_client import AsyncHttpClient
 from gigachat.models.tools import AICheckResult, Balance, OpenApiFunctions, TokensCount
 
 
@@ -51,7 +52,7 @@ def tokens_count_sync(
 
 
 async def tokens_count_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     input_: List[str],
     model: str,
@@ -90,7 +91,7 @@ def functions_convert_sync(
 
 
 async def functions_convert_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     openapi_function: str,
     access_token: Optional[str] = None,
@@ -129,7 +130,7 @@ def ai_check_sync(
 
 
 async def ai_check_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     input_: str,
     model: str,
@@ -169,7 +170,7 @@ def get_balance_sync(
 
 
 async def get_balance_async(
-    client: httpx.AsyncClient,
+    client: AsyncHttpClient,
     *,
     access_token: Optional[str] = None,
 ) -> Balance:

--- a/src/gigachat/api/utils.py
+++ b/src/gigachat/api/utils.py
@@ -27,6 +27,7 @@ from gigachat.exceptions import (
     ServerError,
     UnprocessableEntityError,
 )
+from gigachat.http_client import AsyncHttpClient, AsyncStreamResponse
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,7 @@ def parse_chunk(line: str, model_class: Type[T]) -> Optional[T]:
         return None
 
 
-def build_x_headers(response: httpx.Response) -> Dict[str, Optional[str]]:
+def build_x_headers(response: Union[httpx.Response, AsyncStreamResponse]) -> Dict[str, Optional[str]]:
     """Extract X-Headers from response."""
     return {
         "x-request-id": response.headers.get("x-request-id"),
@@ -94,7 +95,7 @@ def build_x_headers(response: httpx.Response) -> Dict[str, Optional[str]]:
     }
 
 
-def _check_content_type(response: httpx.Response) -> None:
+def _check_content_type(response: Union[httpx.Response, AsyncStreamResponse]) -> None:
     content_type, _, _ = response.headers.get("content-type", "").partition(";")
     if content_type != EVENT_STREAM:
         raise httpx.TransportError(f"Expected response Content-Type to be '{EVENT_STREAM}', got {content_type!r}")
@@ -133,7 +134,7 @@ def _check_response(response: httpx.Response) -> None:
         _raise_for_status(response.url, response.status_code, response.read(), response.headers)
 
 
-async def _acheck_response(response: httpx.Response) -> None:
+async def _acheck_response(response: AsyncStreamResponse) -> None:
     if response.status_code == HTTPStatus.OK:
         _check_content_type(response)
     else:
@@ -154,7 +155,7 @@ def execute_request_sync(client: httpx.Client, kwargs: Dict[str, Any], model_cla
     return build_response(response, model_class)
 
 
-async def execute_request_async(client: httpx.AsyncClient, kwargs: Dict[str, Any], model_class: Type[T]) -> T:
+async def execute_request_async(client: AsyncHttpClient, kwargs: Dict[str, Any], model_class: Type[T]) -> T:
     """Execute async request and parse response."""
     response = await client.request(**kwargs)
     return build_response(response, model_class)
@@ -173,7 +174,7 @@ def execute_stream_sync(client: httpx.Client, kwargs: Dict[str, Any], model_clas
 
 
 async def execute_stream_async(
-    client: httpx.AsyncClient, kwargs: Dict[str, Any], model_class: Type[T]
+    client: AsyncHttpClient, kwargs: Dict[str, Any], model_class: Type[T]
 ) -> AsyncIterator[T]:
     """Execute async streaming request and yield parsed chunks."""
     async with client.stream(**kwargs) as response:

--- a/src/gigachat/client.py
+++ b/src/gigachat/client.py
@@ -17,6 +17,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 
 import httpx
@@ -34,6 +35,7 @@ from gigachat.exceptions import (
     ContentValidationError,
     LengthFinishReasonError,
 )
+from gigachat.http_client import AsyncHttpClient, AsyncHttpClientFactory
 from gigachat.models.auth import AccessToken, Token
 from gigachat.models.batches import Batch, Batches
 from gigachat.models.chat import (
@@ -179,6 +181,7 @@ class _BaseClient:
         key_file_password: Optional[str] = None,
         ssl_context: Optional[ssl.SSLContext] = None,
         flags: Optional[List[str]] = None,
+        http_client: Optional[AsyncHttpClientFactory] = None,
         max_connections: Optional[int] = None,
         max_retries: Optional[int] = None,
         retry_backoff_factor: Optional[float] = None,
@@ -213,6 +216,7 @@ class _BaseClient:
         }
         config = {k: v for k, v in kwargs.items() if v is not None}
         self._settings = Settings(**config)
+        self._http_client_factory = http_client
         if self._settings.access_token:
             self._access_token = AccessToken(access_token=self._settings.access_token, expires_at=0)
 
@@ -290,6 +294,7 @@ class GigaChatSyncClient(_BaseClient):
         key_file_password: Optional[str] = None,
         ssl_context: Optional[ssl.SSLContext] = None,
         flags: Optional[List[str]] = None,
+        http_client: Optional[AsyncHttpClientFactory] = None,
         max_connections: Optional[int] = None,
         max_retries: Optional[int] = None,
         retry_backoff_factor: Optional[float] = None,
@@ -314,6 +319,7 @@ class GigaChatSyncClient(_BaseClient):
             key_file_password=key_file_password,
             ssl_context=ssl_context,
             flags=flags,
+            http_client=http_client,
             max_connections=max_connections,
             max_retries=max_retries,
             retry_backoff_factor=retry_backoff_factor,
@@ -596,6 +602,7 @@ class GigaChatAsyncClient(_BaseClient):
         key_file_password: Optional[str] = None,
         ssl_context: Optional[ssl.SSLContext] = None,
         flags: Optional[List[str]] = None,
+        http_client: Optional[AsyncHttpClientFactory] = None,
         max_connections: Optional[int] = None,
         max_retries: Optional[int] = None,
         retry_backoff_factor: Optional[float] = None,
@@ -620,6 +627,7 @@ class GigaChatAsyncClient(_BaseClient):
             key_file_password=key_file_password,
             ssl_context=ssl_context,
             flags=flags,
+            http_client=http_client,
             max_connections=max_connections,
             max_retries=max_retries,
             retry_backoff_factor=retry_backoff_factor,
@@ -629,19 +637,28 @@ class GigaChatAsyncClient(_BaseClient):
         self.a_assistants = AssistantsAsyncClient(self)
         self.a_threads = ThreadsAsyncClient(self)
         self._async_token_lock = asyncio.Lock()
-        self._aclient_instance: Optional[httpx.AsyncClient] = None
-        self._auth_aclient_instance: Optional[httpx.AsyncClient] = None
+        self._aclient_instance: Optional[AsyncHttpClient] = None
+        self._auth_aclient_instance: Optional[AsyncHttpClient] = None
 
     @property
-    def _aclient(self) -> httpx.AsyncClient:
+    def _aclient(self) -> AsyncHttpClient:
         if self._aclient_instance is None:
-            self._aclient_instance = httpx.AsyncClient(**_get_kwargs(self._settings))
+            if self._http_client_factory is not None:
+                self._aclient_instance = self._http_client_factory.create_client(self._settings)
+            else:
+                self._aclient_instance = cast(AsyncHttpClient, httpx.AsyncClient(**_get_kwargs(self._settings)))
         return self._aclient_instance
 
     @property
-    def _auth_aclient(self) -> httpx.AsyncClient:
+    def _auth_aclient(self) -> AsyncHttpClient:
         if self._auth_aclient_instance is None:
-            self._auth_aclient_instance = httpx.AsyncClient(**_get_auth_kwargs(self._settings))
+            if self._http_client_factory is not None:
+                self._auth_aclient_instance = self._http_client_factory.create_auth_client(self._settings)
+            else:
+                self._auth_aclient_instance = cast(
+                    AsyncHttpClient,
+                    httpx.AsyncClient(**_get_auth_kwargs(self._settings)),
+                )
         return self._auth_aclient_instance
 
     async def aclose(self) -> None:
@@ -895,6 +912,7 @@ class GigaChat(GigaChatSyncClient, GigaChatAsyncClient):
         key_file_password: Optional[str] = None,
         ssl_context: Optional[ssl.SSLContext] = None,
         flags: Optional[List[str]] = None,
+        http_client: Optional[AsyncHttpClientFactory] = None,
         max_connections: Optional[int] = None,
         max_retries: Optional[int] = None,
         retry_backoff_factor: Optional[float] = None,
@@ -919,6 +937,7 @@ class GigaChat(GigaChatSyncClient, GigaChatAsyncClient):
             key_file_password=key_file_password,
             ssl_context=ssl_context,
             flags=flags,
+            http_client=http_client,
             max_connections=max_connections,
             max_retries=max_retries,
             retry_backoff_factor=retry_backoff_factor,


### PR DESCRIPTION
## Description

Add optional `aiohttp` support for async clients via `DefaultAioHttpClient`, following the same UX as the OpenAI and Anthropic Python SDKs.

## Motivation

`httpx` remains the default async backend, but some users want an `aiohttp`-based option for higher-concurrency workloads. This change adds that backend without changing existing sync behavior and exposes it through a public, documented API.

Closes #<issue-number>

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [x] Performance improvement
- [ ] Test coverage improvement
- [ ] CI/CD or tooling change

## Changes Made

- Added optional `http_client` support to async clients and wired `GigaChatAsyncClient`/`GigaChat` to use injected async HTTP client factories for both API and auth requests.
- Updated async API utilities and async endpoint helpers to depend on the shared async transport protocol instead of concrete `httpx.AsyncClient` types.
- Exported `DefaultAioHttpClient`, added the `gigachat[aiohttp]` optional dependency, and documented installation and usage in `README.md`.

## Testing

Targeted async/client/API test suites were run locally to validate the new transport path and confirm no regressions in auth, chat, streaming, files, threads, assistants, batches, and tools.

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] All existing tests pass locally

### Manual Testing

No separate manual API testing was performed. Validation was done through automated tests, linting, and type checking.

```bash
# Targeted pytest runs
.venv\Scripts\pytest.exe tests\unit\gigachat\test_client_http_client.py tests\unit\gigachat\test_client_lifecycle.py tests\unit\gigachat\test_client_constructor.py

.venv\Scripts\pytest.exe tests\unit\gigachat\test_client_chat.py tests\unit\gigachat\test_client_files.py tests\unit\gigachat\test_client_threads.py tests\unit\gigachat\test_client_assistants.py tests\unit\gigachat\test_client_batches.py tests\unit\gigachat\test_client_tools.py tests\unit\gigachat\test_client_connection_limits.py tests\unit\gigachat\api\test_chat.py tests\unit\gigachat\api\test_files.py tests\unit\gigachat\api\test_auth.py tests\unit\gigachat\api\test_tools.py tests\unit\gigachat\api\test_batches.py tests\unit\gigachat\api\test_models.py tests\unit\gigachat\api\test_assistants.py tests\unit\gigachat\api\test_threads.py tests\unit\gigachat\api\test_utils.py

# Lint / type checks
.venv\Scripts\ruff.exe check src\gigachat\client.py src\gigachat\http_client.py src\gigachat\__init__.py src\gigachat\api\utils.py src\gigachat\api\auth.py src\gigachat\api\assistants.py src\gigachat\api\batches.py src\gigachat\api\chat.py src\gigachat\api\embeddings.py src\gigachat\api\files.py src\gigachat\api\models.py src\gigachat\api\threads.py src\gigachat\api\tools.py

.venv\Scripts\mypy.exe src\gigachat\client.py src\gigachat\http_client.py src\gigachat\__init__.py src\gigachat\api\utils.py src\gigachat\api\auth.py src\gigachat\api\assistants.py src\gigachat\api\batches.py src\gigachat\api\chat.py src\gigachat\api\embeddings.py src\gigachat\api\files.py src\gigachat\api\models.py src\gigachat\api\threads.py src\gigachat\api\tools.py
