### PR TITLE
docs: clarify context variables semantics and header mapping

### DIFF
--- a/src/gigachat/context.py
+++ b/src/gigachat/context.py
@@ -1,3 +1,51 @@
+"""Context variables for distributed tracing and request identification.
+
+These variables are injected into HTTP headers via :func:`gigachat.api.utils.build_headers`
+and allow passing tracing/auth context without threading it through every call.
+
+Mapping to HTTP headers
+-----------------------
+
+================================  ====================
+Context Variable                  HTTP Header
+================================  ====================
+``authorization_cvar``            ``Authorization``
+``client_id_cvar``                ``X-Client-ID``
+``request_id_cvar``               ``X-Request-ID``
+``session_id_cvar``               ``X-Session-ID``
+``service_id_cvar``               ``X-Service-ID``
+``operation_id_cvar``             ``X-Operation-ID``
+``trace_id_cvar``                 ``X-Trace-ID``
+``agent_id_cvar``                 ``X-Agent-ID``
+================================  ====================
+
+Tracing semantics
+-----------------
+
+- **trace_id** — identifies an entire business transaction (correlation ID).
+  Stays the same across all calls within one logical operation.
+- **request_id** — identifies a single incoming client request.
+  May equal trace_id when there is one request per transaction.
+- **operation_id** — identifies an individual outgoing call (span ID).
+  Should be regenerated for every call to an external system.
+- **session_id** — ties multiple requests to a single user session.
+
+Example::
+
+    from gigachat.context import trace_id_cvar, request_id_cvar, operation_id_cvar
+
+    # Set once per incoming request
+    trace_id_cvar.set("tx-001")
+    request_id_cvar.set("req-abc")
+
+    # Set a new span for each outgoing call
+    operation_id_cvar.set("span-1")
+    response_1 = gigachat.chat(...)
+
+    operation_id_cvar.set("span-2")
+    response_2 = gigachat.chat(...)
+"""
+
 from contextvars import ContextVar
 from typing import Dict, Optional
 
@@ -15,22 +63,31 @@ __all__ = [
 ]
 
 authorization_cvar: ContextVar[Optional[str]] = ContextVar("authorization_cvar", default=None)
-"""Authorization information using JWE."""
+"""JWE token for authorization. Sent as the ``Authorization`` header, overriding the default token."""
+
 client_id_cvar: ContextVar[Optional[str]] = ContextVar("client_id_cvar", default=None)
-"""Unique client ID."""
+"""Unique client identifier. Sent as ``X-Client-ID``."""
+
 request_id_cvar: ContextVar[Optional[str]] = ContextVar("request_id_cvar", default=None)
-"""Unique request ID."""
+"""Unique incoming request identifier. Sent as ``X-Request-ID``."""
+
 session_id_cvar: ContextVar[Optional[str]] = ContextVar("session_id_cvar", default=None)
-"""Unique session ID."""
+"""User session identifier. Sent as ``X-Session-ID``."""
+
 service_id_cvar: ContextVar[Optional[str]] = ContextVar("service_id_cvar", default=None)
-"""Unique service ID."""
+"""Calling service identifier. Sent as ``X-Service-ID``."""
+
 operation_id_cvar: ContextVar[Optional[str]] = ContextVar("operation_id_cvar", default=None)
-"""Unique operation ID."""
+"""Individual operation (span) identifier for tracing. Sent as ``X-Operation-ID``."""
+
 trace_id_cvar: ContextVar[Optional[str]] = ContextVar("trace_id_cvar", default=None)
-"""Unique process instance ID (main operation)."""
+"""End-to-end trace identifier (correlation ID) for the entire business transaction. Sent as ``X-Trace-ID``."""
+
 agent_id_cvar: ContextVar[Optional[str]] = ContextVar("agent_id_cvar", default=None)
-"""Unique agent ID."""
+"""Agent identifier. Sent as ``X-Agent-ID``."""
+
 custom_headers_cvar: ContextVar[Optional[Dict[str, str]]] = ContextVar("custom_headers_cvar", default=None)
-"""Additional HTTP headers to be added to the request."""
+"""Additional HTTP headers to be added to every request."""
+
 chat_url_cvar: ContextVar[str] = ContextVar("chat_url_cvar", default="/chat/completions")
-"""Custom URL for chat/completions if a different chat URL is required."""
+"""Custom URL path for chat completions endpoint."""


### PR DESCRIPTION
## Summary

Addresses #79 — context variables lack documentation on their purpose, HTTP header mapping, and tracing semantics.

**Changes to `src/gigachat/context.py`:**

- Add module-level docstring with:
  - Table mapping each `ContextVar` to its HTTP header (from `build_headers()`)
  - Tracing semantics: `trace_id` (correlation ID) vs `request_id` (per-request) vs `operation_id` (per-span)
  - Usage example for distributed tracing
- Update individual variable docstrings to describe purpose and corresponding header

**No code logic changes** — only documentation. All 17 existing tests pass.

## Test plan

- [x] `tests/unit/gigachat/test_context.py` — 2 passed
- [x] `tests/unit/gigachat/api/test_utils.py` — 15 passed (covers `build_headers`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)