### PR TITLE
Structured output version release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gigachat"
-version = "0.2.1a1"
+version = "0.2.1"
 description = "GigaChat. Python-library for GigaChat API"
 authors = [
     { name = "Konstantin Krestnikov", email = "rai220@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gigachat"
-version = "0.2.1"
+version = "0.2.1a2"
 description = "GigaChat. Python-library for GigaChat API"
 authors = [
     { name = "Konstantin Krestnikov", email = "rai220@gmail.com" },

--- a/src/gigachat/exceptions.py
+++ b/src/gigachat/exceptions.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Union
 
 import httpx
 
@@ -31,10 +29,10 @@ class ResponseError(GigaChatException):
 
     def __init__(
         self,
-        url: httpx.URL | str,
+        url: Union[httpx.URL, str],
         status_code: int,
-        content: bytes | None,
-        headers: httpx.Headers | None,
+        content: Optional[bytes],
+        headers: Optional[httpx.Headers],
     ) -> None:
         self.url = url
         self.status_code = status_code
@@ -93,6 +91,6 @@ class ServerError(ResponseError):
 class LengthFinishReasonError(GigaChatException):
     """Exception raised when finish_reason is 'length' (response truncated)."""
 
-    def __init__(self, completion: ChatCompletion) -> None:
+    def __init__(self, completion: "ChatCompletion") -> None:
         self.completion = completion
         super().__init__("Could not parse response content as the length limit was reached")

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.1a1"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.1"
+version = "0.2.1a2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
## Summary
Pre-release `0.2.1a2` for testing the structured output (JSON Schema) feature and the related Python 3.8 compatibility fixes already on `main` (#104)

Not a final release — published as an alpha for validation before `0.2.1`
## Changes                                                                                                                                              
- bump `pyproject.toml` / `uv.lock` → `0.2.1a2`