### PR TITLE
docs: document function ranker settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ with GigaChat() as client:
         print(f"Arguments: {message.function_call.arguments}")
 ```
 
+> **Note:** By default, `function_ranker` is not sent.
+
+Enable function/tool ranking explicitly and limit the number of ranked functions:
+
+```python
+chat = Chat(
+    messages=[Messages(role=MessagesRole.USER, content="What's the weather in Tokyo?")],
+    functions=[weather_function],
+    function_ranker={"enabled": True, "top_n": 3},
+)
+```
+
 ### Structured Output (JSON Schema) — Beta
 
 > **Note:** This feature is in beta. It may not work correctly with all model versions.


### PR DESCRIPTION
## Summary
- Clarify that `function_ranker` is not sent by default.
- Add a README example for enabling function/tool ranking with a `top_n` limit.

## Test plan
- `uv run pytest tests/unit/gigachat/models/test_chat.py::test_chat_function_ranker_from_dict tests/unit/gigachat/models/test_chat.py::test_chat_function_ranker_omitted_by_default`
- Pre-commit hooks run during commit


Made with [Cursor](https://cursor.com)