### PR TITLE
fix: map profanity check to primary disable filter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gigachat"
-version = "0.2.2a1"
+version = "0.2.2a2"
 description = "GigaChat. Python-library for GigaChat API"
 authors = [
     { name = "Konstantin Krestnikov", email = "rai220@gmail.com" },

--- a/src/gigachat/client.py
+++ b/src/gigachat/client.py
@@ -173,6 +173,8 @@ def _parse_chat_completion(
     )
     if not using_assistant and chat.model is None:
         chat.model = settings.model or GIGACHAT_MODEL
+    if chat.disable_filter is None and settings.profanity_check is not None:
+        chat.disable_filter = not settings.profanity_check
     if chat.flags is None:
         chat.flags = settings.flags
     return chat

--- a/src/gigachat/models/chat_completions.py
+++ b/src/gigachat/models/chat_completions.py
@@ -411,6 +411,11 @@ class ChatCompletionRequest(_ChatCompletionsModel):
     user_info: Optional[ChatUserInfo] = Field(default=None, description="End-user metadata.")
     stream: Optional[bool] = Field(default=None, description="Stream response fragments.")
     disable_filter: Optional[bool] = Field(default=None, description="Disable filtering.")
+    profanity_check: Optional[bool] = Field(
+        default=None,
+        exclude=True,
+        description="Enable profanity filtering.",
+    )
     flags: Optional[List[str]] = Field(default=None, description="Feature flags.")
 
     @model_validator(mode="before")
@@ -441,6 +446,12 @@ class ChatCompletionRequest(_ChatCompletionsModel):
             values["model_options"] = model_options
 
         return values
+
+    @model_validator(mode="after")
+    def _map_profanity_check(self) -> "ChatCompletionRequest":
+        if self.disable_filter is None and self.profanity_check is not None:
+            self.disable_filter = not self.profanity_check
+        return self
 
     @property
     def reasoning(self) -> Optional[ChatReasoning]:

--- a/tests/unit/gigachat/api/test_chat_completions.py
+++ b/tests/unit/gigachat/api/test_chat_completions.py
@@ -50,6 +50,18 @@ def test_get_stream_kwargs_sets_primary_stream_payload() -> None:
     assert request_content["messages"][0]["content"] == [{"text": "solve 2+2"}]
 
 
+def test_build_request_json_maps_profanity_check_to_disable_filter() -> None:
+    chat_data = ChatCompletionRequest(
+        messages=[ChatMessage(role="user", content="solve 2+2")],
+        profanity_check=False,
+    )
+
+    request_content = chat_completions._build_request_json(chat_data)
+
+    assert request_content["disable_filter"] is True
+    assert "profanity_check" not in request_content
+
+
 def test_stream_sync_parses_primary_chunk(httpx_mock: HTTPXMock) -> None:
     httpx_mock.add_response(url=MOCK_URL, content=PRIMARY_CHAT_COMPLETION_STREAM, headers=HEADERS_STREAM)
     chat_data = ChatCompletionRequest(messages=[ChatMessage(role="user", content="solve 2+2")])

--- a/tests/unit/gigachat/test_client_chat.py
+++ b/tests/unit/gigachat/test_client_chat.py
@@ -130,6 +130,47 @@ def test__parse_chat_profanity_check(
 @pytest.mark.parametrize(
     ("payload_value", "setting_value", "expected"),
     [
+        (None, None, None),
+        (None, False, True),
+        (None, True, False),
+        (False, None, True),
+        (False, False, True),
+        (False, True, True),
+        (True, None, False),
+        (True, False, False),
+        (True, True, False),
+    ],
+)
+def test__parse_chat_completion_profanity_check(
+    payload_value: Optional[bool],
+    setting_value: Optional[bool],
+    expected: Optional[bool],
+) -> None:
+    actual = _parse_chat_completion(
+        ChatCompletionRequest(
+            messages=[ChatMessage(role="user", content="text")],
+            profanity_check=payload_value,
+        ),
+        Settings(profanity_check=setting_value),
+    )
+    assert actual.disable_filter is expected
+
+
+def test__parse_chat_completion_disable_filter_takes_precedence() -> None:
+    actual = _parse_chat_completion(
+        ChatCompletionRequest(
+            messages=[ChatMessage(role="user", content="text")],
+            disable_filter=False,
+            profanity_check=False,
+        ),
+        Settings(profanity_check=False),
+    )
+    assert actual.disable_filter is False
+
+
+@pytest.mark.parametrize(
+    ("payload_value", "setting_value", "expected"),
+    [
         (None, None, GIGACHAT_MODEL),
         (None, "setting_model", "setting_model"),
         ("payload_model", None, "payload_model"),

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.2a1"
+version = "0.2.2a2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
## Description

Maps the public `profanity_check` setting to the primary `/v2/chat/completions` request field `disable_filter`.

When `profanity_check=False`, the SDK now sends `disable_filter=True` for primary chat completions. Explicit `disable_filter` values keep precedence.

## Motivation

The legacy chat API uses `profanity_check`, while the primary `/v2/chat/completions` API expects the inverse `disable_filter` flag. Without this mapping, the client-level default `profanity_check` was not propagated to primary chat requests.

Closes #N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD or tooling change

## Changes Made

- Added `profanity_check` as a compatibility input on `ChatCompletionRequest`, excluded from serialized request JSON.
- Mapped `profanity_check` to `disable_filter` with inverted semantics for primary chat completions.
- Propagated `Settings.profanity_check` default into primary chat requests when `disable_filter` is not explicitly set.
- Added unit coverage for direct payload mapping, settings fallback, and explicit `disable_filter` precedence.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] All existing tests pass locally

### Manual Testing

```bash
uv run pytest tests/unit/gigachat/test_client_chat.py tests/unit/gigachat/api/test_chat_completions.py tests/unit/gigachat/models/test_chat_completions.py
uv run ruff check src/gigachat/client.py src/gigachat/models/chat_completions.py tests/unit/gigachat/test_client_chat.py tests/unit/gigachat/api/test_chat_completions.py
uv run ruff format --check src/gigachat/client.py src/gigachat/models/chat_completions.py tests/unit/gigachat/test_client_chat.py tests/unit/gigachat/api/test_chat_completions.py
uv run mypy src tests
```

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new linter warnings (`make lint`)
- [x] Type checking passes (`make mypy`)
- [ ] All tests pass (`make test`)

### Documentation

- [ ] I have updated the documentation accordingly
- [x] Docstrings follow Google style with imperative mood
- [ ] I have added examples for new features (if applicable)
- [ ] README.md updated (if applicable)

### Dependencies

- [x] No new dependencies added
- [ ] If dependencies added, they are justified and minimal
- [ ] `uv.lock` updated (if dependencies changed)

### Compatibility

- [x] Changes are compatible with Python 3.8-3.13
- [x] No use of `type[...]` syntax (use `Type[...]` for Python 3.8)
- [x] Async/sync variants both work correctly (if applicable)

### Commits

- [x] Commit messages are clear and follow conventional commits style
- [x] Commits are logically organized
- [x] No debug code or commented-out code left in

## Additional Context

`disable_filter` remains the primary API field. `profanity_check` is accepted as an SDK compatibility input and is not serialized into the primary request body.

## Pre-merge Actions

- [ ] Changelog updated (if applicable)
- [ ] Version bump considered (if applicable)
