### PR TITLE
fix: normalize boolean storage in primary chat completions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gigachat"
-version = "0.2.2a2"
+version = "0.2.2a3"
 description = "GigaChat. Python-library for GigaChat API"
 authors = [
     { name = "Konstantin Krestnikov", email = "rai220@gmail.com" },

--- a/src/gigachat/models/chat_completions.py
+++ b/src/gigachat/models/chat_completions.py
@@ -404,7 +404,10 @@ class ChatCompletionRequest(_ChatCompletionsModel):
     tools_state_id: Optional[str] = Field(default=None, description="Tool execution state identifier.")
     model_options: Optional[ChatModelOptions] = Field(default=None, description="Model generation options.")
     filter_config: Optional[ChatFilterConfig] = Field(default=None, description="Filtering configuration.")
-    storage: Optional[Union[ChatStorage, bool]] = Field(default=None, description="Thread storage settings.")
+    storage: Optional[Union[ChatStorage, bool]] = Field(
+        default=None,
+        description="Thread storage settings. `True` enables storage with defaults; `False` disables it.",
+    )
     ranker_options: Optional[ChatRankerOptions] = Field(default=None, description="Tool ranking settings.")
     tool_config: Optional[ChatToolConfig] = Field(default=None, description="Tool calling configuration.")
     tools: Optional[List[ChatTool]] = Field(default=None, description="Available tools.")
@@ -427,6 +430,12 @@ class ChatCompletionRequest(_ChatCompletionsModel):
         values = dict(values)
 
         _normalize_tools_state_id(values)
+
+        storage = values.get("storage")
+        if storage is True:
+            values["storage"] = {}
+        elif storage is False:
+            values["storage"] = None
 
         model_options = values.get("model_options")
         if model_options is None:

--- a/tests/unit/gigachat/api/test_chat_completions.py
+++ b/tests/unit/gigachat/api/test_chat_completions.py
@@ -5,7 +5,7 @@ from pytest_httpx import HTTPXMock
 
 from gigachat.api import chat_completions
 from gigachat.context import chat_completions_url_cvar
-from gigachat.models.chat_completions import ChatCompletionChunk, ChatCompletionRequest, ChatMessage
+from gigachat.models.chat_completions import ChatCompletionChunk, ChatCompletionRequest, ChatMessage, ChatStorage
 from tests.constants import BASE_URL, HEADERS_STREAM, MOCK_URL
 
 PRIMARY_CHAT_COMPLETION_STREAM = (
@@ -60,6 +60,39 @@ def test_build_request_json_maps_profanity_check_to_disable_filter() -> None:
 
     assert request_content["disable_filter"] is True
     assert "profanity_check" not in request_content
+
+
+def test_build_request_json_maps_storage_true_to_object() -> None:
+    chat_data = ChatCompletionRequest(
+        messages=[ChatMessage(role="user", content="solve 2+2")],
+        storage=True,
+    )
+
+    request_content = chat_completions._build_request_json(chat_data)
+
+    assert request_content["storage"] == {}
+
+
+def test_build_request_json_omits_storage_when_false() -> None:
+    chat_data = ChatCompletionRequest(
+        messages=[ChatMessage(role="user", content="solve 2+2")],
+        storage=False,
+    )
+
+    request_content = chat_completions._build_request_json(chat_data)
+
+    assert "storage" not in request_content
+
+
+def test_build_request_json_keeps_storage_object() -> None:
+    chat_data = ChatCompletionRequest(
+        messages=[ChatMessage(role="user", content="solve 2+2")],
+        storage=ChatStorage(thread_id="thread-1", limit=10),
+    )
+
+    request_content = chat_completions._build_request_json(chat_data)
+
+    assert request_content["storage"] == {"thread_id": "thread-1", "limit": 10}
 
 
 def test_stream_sync_parses_primary_chunk(httpx_mock: HTTPXMock) -> None:

--- a/tests/unit/gigachat/models/test_chat_completions.py
+++ b/tests/unit/gigachat/models/test_chat_completions.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel, ValidationError
 
 from gigachat.models import ChatCompletionRequest, ChatCompletionResponse, ChatMessage
-from gigachat.models.chat_completions import ChatCompletionChunk, ChatResponseFormat
+from gigachat.models.chat_completions import ChatCompletionChunk, ChatResponseFormat, ChatStorage
 
 
 class WeatherAnswer(BaseModel):
@@ -168,7 +168,7 @@ def test_chat_completion_request_accepts_regex_response_format() -> None:
     }
 
 
-def test_chat_completion_request_accepts_storage_bool_future_shape() -> None:
+def test_chat_completion_request_normalizes_storage_true_to_object() -> None:
     request = ChatCompletionRequest.model_validate(
         {
             "messages": [{"role": "user", "content": "Сохрани контекст"}],
@@ -178,8 +178,22 @@ def test_chat_completion_request_accepts_storage_bool_future_shape() -> None:
 
     dumped = request.model_dump(exclude_none=True, by_alias=True)
 
-    assert request.storage is True
-    assert dumped["storage"] is True
+    assert isinstance(request.storage, ChatStorage)
+    assert dumped["storage"] == {}
+
+
+def test_chat_completion_request_drops_storage_when_false() -> None:
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Не сохраняй контекст"}],
+            "storage": False,
+        }
+    )
+
+    dumped = request.model_dump(exclude_none=True, by_alias=True)
+
+    assert request.storage is None
+    assert "storage" not in dumped
 
 
 def test_chat_completion_response_parses_primary_contract() -> None:

--- a/tests/unit/gigachat/test_client_chat.py
+++ b/tests/unit/gigachat/test_client_chat.py
@@ -24,6 +24,7 @@ from gigachat.models import (
     ChatCompletionRequest,
     ChatCompletionResponse,
     ChatMessage,
+    ChatStorage,
     Messages,
     MessagesRole,
 )
@@ -202,7 +203,7 @@ def test__parse_chat_completion_preserves_missing_model_for_assistant() -> None:
     assert actual.assistant_id == "assistant-1"
 
 
-def test__parse_chat_completion_accepts_storage_bool() -> None:
+def test__parse_chat_completion_normalizes_storage_bool() -> None:
     actual = _parse_chat_completion(
         {
             "messages": [{"role": "user", "content": "text"}],
@@ -211,7 +212,7 @@ def test__parse_chat_completion_accepts_storage_bool() -> None:
         Settings(model="setting_model"),
     )
 
-    assert actual.storage is True
+    assert isinstance(actual.storage, ChatStorage)
     assert actual.model == "setting_model"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.2a2"
+version = "0.2.2a3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
## Summary

The primary `/v2/chat/completions` server rejects a bare boolean `storage`
field with **HTTP 400 "invalid JSON syntax"**. `ChatCompletionRequest.storage`
is typed `Optional[Union[ChatStorage, bool]]`, so `storage=True` serialized to
`"storage": true` and always failed against the live endpoint, while the object
forms (`ChatStorage()`, `{...}`) worked.

This normalizes the boolean shorthand at request build time:

- `storage=True` → `{}` (enable storage with defaults; server returns a `thread_id`)
- `storage=False` → field omitted (opt out)
- `storage=ChatStorage(...)` / dict → unchanged

The `bool` shorthand stays in the public type and now works on the wire instead
of erroring. This is **v2-only**; the legacy `Chat.storage` (`Optional[Storage]`,
enabled via the in-object `is_stateful` flag) is unaffected.

## Changes

- `models/chat_completions.py`: normalize boolean `storage` in the
  `ChatCompletionRequest` before-validator; clarify the field description.
- Unit tests: serialization (`storage` True/False/object), model normalization,
  and `_parse_chat_completion` behavior. Updated the prior tests that asserted the
  old (rejected) `storage: true` shape.

## Test plan

- [x] `make all` (ruff lint + format, mypy strict, 485 unit tests) passes
- [x] Live `/v2/chat/completions`: `storage=True` now returns a `thread_id`
  (previously HTTP 400); `storage=False` sends no storage
- [x] Python 3.8–3.13 compatible (`Optional`/`Union`, no new syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)