### PR TITLE
fix: load mTLS cert into SSL context

### DIFF
--- a/src/gigachat/client.py
+++ b/src/gigachat/client.py
@@ -65,6 +65,24 @@ logger = logging.getLogger(__name__)
 GIGACHAT_MODEL = "GigaChat"
 
 
+def _get_ssl_context(settings: Settings, *, load_client_cert: bool) -> Optional[ssl.SSLContext]:
+    """Build an SSL context for custom trust stores and client certificates."""
+    if settings.ssl_context is not None:
+        context = settings.ssl_context
+    elif settings.ca_bundle_file:
+        context = ssl.create_default_context(cafile=settings.ca_bundle_file)
+    else:
+        return None
+
+    if load_client_cert and settings.cert_file:
+        context.load_cert_chain(
+            certfile=settings.cert_file,
+            keyfile=settings.key_file,
+            password=settings.key_file_password,
+        )
+    return context
+
+
 def _get_kwargs(settings: Settings) -> Dict[str, Any]:
     """Return settings for connecting to the GigaChat API."""
     kwargs = {
@@ -72,11 +90,10 @@ def _get_kwargs(settings: Settings) -> Dict[str, Any]:
         "verify": settings.verify_ssl_certs,
         "timeout": httpx.Timeout(settings.timeout),
     }
-    if settings.ssl_context:
-        kwargs["verify"] = settings.ssl_context
-    if settings.ca_bundle_file:
-        kwargs["verify"] = settings.ca_bundle_file
-    if settings.cert_file:
+    context = _get_ssl_context(settings, load_client_cert=True)
+    if context is not None:
+        kwargs["verify"] = context
+    elif settings.cert_file:
         kwargs["cert"] = (
             settings.cert_file,
             settings.key_file,
@@ -93,10 +110,9 @@ def _get_auth_kwargs(settings: Settings) -> Dict[str, Any]:
         "verify": settings.verify_ssl_certs,
         "timeout": httpx.Timeout(settings.timeout),
     }
-    if settings.ssl_context:
-        kwargs["verify"] = settings.ssl_context
-    if settings.ca_bundle_file:
-        kwargs["verify"] = settings.ca_bundle_file
+    context = _get_ssl_context(settings, load_client_cert=False)
+    if context is not None:
+        kwargs["verify"] = context
     return kwargs
 
 

--- a/tests/unit/gigachat/test_client_core.py
+++ b/tests/unit/gigachat/test_client_core.py
@@ -29,8 +29,25 @@ def _make_ssl_context() -> ssl.SSLContext:
 
 
 def test__get_kwargs() -> None:
-    settings = Settings(ca_bundle_file="ca.pem", cert_file="tls.pem", key_file="tls.key")
-    assert _get_kwargs(settings)
+    context = mock.Mock(spec=ssl.SSLContext)
+    settings = Settings(
+        ca_bundle_file="ca.pem",
+        cert_file="tls.pem",
+        key_file="tls.key",
+        key_file_password="secret",
+    )
+
+    with mock.patch("gigachat.client.ssl.create_default_context", return_value=context) as create_context:
+        kwargs = _get_kwargs(settings)
+
+    create_context.assert_called_once_with(cafile="ca.pem")
+    context.load_cert_chain.assert_called_once_with(
+        certfile="tls.pem",
+        keyfile="tls.key",
+        password="secret",
+    )
+    assert kwargs["verify"] is context
+    assert "cert" not in kwargs
 
 
 def test__get_kwargs_ssl() -> None:
@@ -40,8 +57,15 @@ def test__get_kwargs_ssl() -> None:
 
 
 def test__get_auth_kwargs() -> None:
+    context = mock.Mock(spec=ssl.SSLContext)
     settings = Settings(ca_bundle_file="ca.pem", cert_file="tls.pem", key_file="tls.key")
-    assert _get_auth_kwargs(settings)
+
+    with mock.patch("gigachat.client.ssl.create_default_context", return_value=context) as create_context:
+        kwargs = _get_auth_kwargs(settings)
+
+    create_context.assert_called_once_with(cafile="ca.pem")
+    context.load_cert_chain.assert_not_called()
+    assert kwargs["verify"] is context
 
 
 def test__get_auth_kwargs_ssl() -> None:


### PR DESCRIPTION
## Description

Build an `ssl.SSLContext` when a custom CA bundle is configured and load the client certificate chain into that context before passing it to HTTPX.

## Motivation

With HTTPX 0.28.1, the combination `verify=<CA path>` plus `cert=(...)` can return from SSL-context construction before loading the client certificate. The SDK currently emits exactly that combination for mTLS, which explains the `TLSV13_ALERT_CERTIFICATE_REQUIRED` regression reported in #64. HTTPX now documents `SSLContext.load_cert_chain()` as the supported client-certificate configuration.

Closes #64

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test coverage improvement

## Changes Made

- Build a custom SSL context for `ca_bundle_file` instead of passing a string `verify` value.
- Load `cert_file`, `key_file`, and `key_file_password` directly into that context.
- Add a regression test asserting that the client certificate is loaded and the problematic `cert` kwarg is not emitted.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests not applicable (transport construction is covered without credentials)
- [x] All existing tests pass locally

### Manual Testing

```text
ruff check: passed
ruff format --check: passed
mypy --strict: passed
pytest: 485 passed, 33 deselected
httpx 0.28.1 reproduction before fix: client was created with missing cert files
httpx 0.28.1 after fix: load_cert_chain is attempted before connection
```

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new linter warnings
- [x] Type checking passes
- [x] All tests pass

### Documentation

- [x] Docstrings follow Google style with imperative mood
- [x] No user-facing documentation change is required

### Dependencies

- [x] No new dependencies added
- [x] Lockfile unchanged

### Compatibility

- [x] Changes use Python 3.8-compatible syntax
- [x] Sync and async clients share the corrected transport configuration

### Commits

- [x] Commit follows conventional commits style
- [x] No debug or commented-out code

## Additional Context

- HTTPX SSL guidance: https://www.python-httpx.org/advanced/ssl/#client-side-certificates
- HTTPX 0.28 behavior for `verify=<path>` plus `cert`: https://github.com/encode/httpx/discussions/3454