### PR TITLE
chore: release 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gigachat"
-version = "0.2.3a1"
+version = "0.2.3"
 description = "GigaChat. Python-library for GigaChat API"
 authors = [
     { name = "Konstantin Krestnikov", email = "rai220@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.3a1"
+version = "0.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
## Что это

Промоут `0.2.3a1` → `0.2.3`. Кода не трогает: только версия в `pyproject.toml` и `uv.lock`. Альфу обкатали в даунстримах, регрессий не поймали.

## Что уезжает в стабильный релиз (с v0.2.1)

- `feat!`: дефолтный base URL — `https://api.giga.chat/v1` (#119). **Ломающее**: старый хост `gigachat.devices.sberbank.ru/api/v1` больше не подставляется по умолчанию, а auth по user/password требует явного `base_url`.
- `feat`: resource API v2 — `client.chat.create(...)`, модели `chat_completions` (#109, #112).
- `fix`: нормализация boolean в `storage` у primary chat completions (#115).
- `fix`: маппинг profanity check на primary disable filter (#114).
- `docs`: настройки function ranker (#108).

## Проверки

Локально на 3.13, до пуша:

- `make all` (ruff format/check, mypy strict, unit) — 501 passed
- `CI=true uv run pytest -m integration --record-mode=none` — 33 passed

> Без `CI=true` интеграционные падают локально: `tests/integration/conftest.py` подтягивает `.env`, и auth уезжает на стенд, отличный от записанного в кассетах. Артефакт локального окружения, не регрессия.

## После мержа

Тег `v0.2.3`, GitHub Release и публикация на PyPI (сейчас latest там — `0.2.1`).