### PR TITLE
Bugfix/token exp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gigachat"
-version = "0.2.3"
+version = "0.2.4"
 description = "GigaChat. Python-library for GigaChat API"
 authors = [
     { name = "Konstantin Krestnikov", email = "rai220@gmail.com" },

--- a/src/gigachat/client.py
+++ b/src/gigachat/client.py
@@ -245,7 +245,10 @@ def _parse_primary_completion(
 
 
 def _build_access_token(token: Token) -> AccessToken:
-    return AccessToken(access_token=token.tok, expires_at=token.exp, x_headers=token.x_headers)
+    expires_at = token.exp
+    if expires_at < 10_000_000_000:
+        expires_at *= 1000
+    return AccessToken(access_token=token.tok, expires_at=expires_at, x_headers=token.x_headers)
 
 
 class _BaseClient:

--- a/src/gigachat/models/auth.py
+++ b/src/gigachat/models/auth.py
@@ -14,4 +14,4 @@ class Token(APIResponse):
     """Raw token response."""
 
     tok: str = Field(description="Generated Access Token.")
-    exp: int = Field(description="Unix timestamp (in milliseconds) when the Access Token expires.")
+    exp: int = Field(description="Unix timestamp (in seconds or milliseconds) when the Access Token expires.")

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -18,6 +18,10 @@ EXPIRES_AT_EXPIRED = 946684800000
 # 2100-01-01 00:00:00 UTC - always valid
 EXPIRES_AT_VALID = 4102444800000
 
+# Password auth /token returns expiration timestamps in seconds
+PASSWORD_EXPIRES_AT_EXPIRED = EXPIRES_AT_EXPIRED // 1000
+PASSWORD_EXPIRES_AT_VALID = EXPIRES_AT_VALID // 1000
+
 # Mock token string (same for all variants)
 MOCK_TOKEN_STRING = (
     "eyJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiYWxnIjoiUlNBLU9BRVAtMjU2In0."
@@ -67,8 +71,8 @@ OAUTH_TOKEN_VALID = {"access_token": MOCK_TOKEN_STRING, "expires_at": EXPIRES_AT
 OAUTH_TOKEN_EXPIRED = {"access_token": MOCK_TOKEN_STRING, "expires_at": EXPIRES_AT_EXPIRED}
 
 # Test Data - Password auth token variants (/token endpoint, tok/exp format)
-PASSWORD_TOKEN_VALID = {"tok": MOCK_TOKEN_STRING, "exp": EXPIRES_AT_VALID}
-PASSWORD_TOKEN_EXPIRED = {"tok": MOCK_TOKEN_STRING, "exp": EXPIRES_AT_EXPIRED}
+PASSWORD_TOKEN_VALID = {"tok": MOCK_TOKEN_STRING, "exp": PASSWORD_EXPIRES_AT_VALID}
+PASSWORD_TOKEN_EXPIRED = {"tok": MOCK_TOKEN_STRING, "exp": PASSWORD_EXPIRES_AT_EXPIRED}
 CHAT = Chat.model_validate(get_json("chat.json"))
 CHAT_FUNCTION = Chat.model_validate(get_json("chat_function.json"))
 CHAT_COMPLETION = get_json("chat_completion.json")

--- a/tests/unit/gigachat/test_client_chat.py
+++ b/tests/unit/gigachat/test_client_chat.py
@@ -629,7 +629,7 @@ def test_chat_credentials_expired_token_refresh(httpx_mock: HTTPXMock) -> None:
 
 
 def test_chat_user_password_token_reuse(httpx_mock: HTTPXMock) -> None:
-    """Verify that valid token is reused with user/password auth."""
+    """Verify that a seconds-based token expiration is normalized and reused."""
     httpx_mock.add_response(url=TOKEN_URL, json=PASSWORD_TOKEN_VALID)
     httpx_mock.add_response(url=CHAT_URL, json=CHAT_COMPLETION)
     httpx_mock.add_response(url=CHAT_URL, json=CHAT_COMPLETION)
@@ -640,6 +640,7 @@ def test_chat_user_password_token_reuse(httpx_mock: HTTPXMock) -> None:
 
     assert isinstance(response1, ChatCompletion)
     assert isinstance(response2, ChatCompletion)
+    assert sum(str(request.url) == TOKEN_URL for request in httpx_mock.get_requests()) == 1
 
 
 def test_chat_user_password_expired_token_refresh(httpx_mock: HTTPXMock) -> None:
@@ -1314,7 +1315,7 @@ async def test_achat_credentials_expired_token_refresh(httpx_mock: HTTPXMock) ->
 
 
 async def test_achat_user_password_token_reuse(httpx_mock: HTTPXMock) -> None:
-    """Verify that valid token is reused with async user/password auth."""
+    """Verify that a seconds-based token expiration is normalized and reused."""
     httpx_mock.add_response(url=TOKEN_URL, json=PASSWORD_TOKEN_VALID)
     httpx_mock.add_response(url=CHAT_URL, json=CHAT_COMPLETION)
     httpx_mock.add_response(url=CHAT_URL, json=CHAT_COMPLETION)
@@ -1325,6 +1326,7 @@ async def test_achat_user_password_token_reuse(httpx_mock: HTTPXMock) -> None:
 
     assert isinstance(response1, ChatCompletion)
     assert isinstance(response2, ChatCompletion)
+    assert sum(str(request.url) == TOKEN_URL for request in httpx_mock.get_requests()) == 1
 
 
 async def test_achat_user_password_expired_token_refresh(httpx_mock: HTTPXMock) -> None:

--- a/tests/unit/gigachat/test_client_core.py
+++ b/tests/unit/gigachat/test_client_core.py
@@ -18,6 +18,7 @@ from tests.constants import (
     BASE_URL,
     CREDENTIALS,
     OAUTH_TOKEN_VALID,
+    PASSWORD_EXPIRES_AT_VALID,
     PASSWORD_TOKEN_VALID,
     TOKEN_URL,
 )
@@ -87,10 +88,10 @@ def test_get_token_password(httpx_mock: HTTPXMock) -> None:
 
     assert model._access_token is not None
     assert model._access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
+    assert model._access_token.expires_at == PASSWORD_EXPIRES_AT_VALID * 1000
     assert access_token is not None
     assert access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
+    assert access_token.expires_at == PASSWORD_EXPIRES_AT_VALID * 1000
 
 
 def test_get_token_manual() -> None:
@@ -162,10 +163,10 @@ async def test_aget_token_password(httpx_mock: HTTPXMock) -> None:
 
     assert model._access_token is not None
     assert model._access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
+    assert model._access_token.expires_at == PASSWORD_EXPIRES_AT_VALID * 1000
     assert access_token is not None
     assert access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
+    assert access_token.expires_at == PASSWORD_EXPIRES_AT_VALID * 1000
 
 
 async def test_aget_token_manual() -> None:

--- a/tests/unit/gigachat/test_client_core.py
+++ b/tests/unit/gigachat/test_client_core.py
@@ -87,10 +87,10 @@ def test_get_token_password(httpx_mock: HTTPXMock) -> None:
 
     assert model._access_token is not None
     assert model._access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"]
+    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
     assert access_token is not None
     assert access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"]
+    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
 
 
 def test_get_token_manual() -> None:
@@ -162,10 +162,10 @@ async def test_aget_token_password(httpx_mock: HTTPXMock) -> None:
 
     assert model._access_token is not None
     assert model._access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"]
+    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
     assert access_token is not None
     assert access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"]
+    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
 
 
 async def test_aget_token_manual() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
## Description

Fixes repeated `/token` requests for user/password authentication when the endpoint returns `Token.exp` as a Unix timestamp in seconds.

The SDK now normalizes seconds to milliseconds while building the cached `AccessToken`. OAuth responses already use millisecond-based `expires_at` values and remain unchanged. The package version is bumped from `0.2.3` to `0.2.4`.

## Motivation

The password-auth `/token` endpoint returns a 10-digit expiration value such as `1785933835`, while the SDK checks cached token validity against `time.time() * 1000`.

Without normalization, a newly issued token is immediately treated as expired, so every API call triggers another `POST /token`. Converting second-based values at the `Token` → `AccessToken` boundary keeps the internal expiration unit consistent without changing the OAuth path.

No issue is linked.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD or tooling change

## Changes Made

- Normalize `Token.exp` values below `10_000_000_000` from seconds to milliseconds in `src/gigachat/client.py::_build_access_token()`; already millisecond-based values are preserved.
- Document that raw `Token.exp` may contain seconds or milliseconds while keeping `AccessToken.expires_at` millisecond-based.
- Update password-auth fixtures to match the seconds-based `/token` response and verify sync and async clients make exactly one token request across two consecutive API calls.
- Use typed expiration constants in token tests so the full mypy gate passes.
- Bump the package version to `0.2.4` in `pyproject.toml` and `uv.lock`.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not applicable)
- [x] All existing tests pass locally

### Manual Testing

```bash
make lint
# Passed: Ruff checks and format verification

make test
# Passed: 501 tests, 33 deselected, 93% coverage

make mypy
# Passed: no issues found in 84 source files
```

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new linter warnings (`make lint`)
- [x] Type checking passes (`make mypy`)
- [x] All tests pass (`make test`)

### Documentation

- [x] I have updated the documentation accordingly
- [x] Docstrings follow Google style with imperative mood
- [ ] I have added examples for new features (not applicable)
- [ ] README.md updated (not applicable)

### Dependencies

- [x] No new dependencies added
- [ ] If dependencies added, they are justified and minimal (not applicable)
- [x] `uv.lock` updated

### Compatibility

- [x] Changes are compatible with Python 3.8-3.13
- [x] No use of `type[...]` syntax (uses Python 3.8-compatible syntax)
- [x] Async/sync variants both work correctly

### Commits

- [x] Commit messages are clear and follow conventional commits style
- [x] Commits are logically organized
- [x] No debug code or commented-out code left in

## Additional Context

No additional context.

## Pre-merge Actions

- [ ] Changelog updated (if applicable)
- [x] Version bump considered and applied (`0.2.4`)
