### PR TITLE
fix: preserve function JSON schemas in v1 requests

### DIFF
--- a/src/gigachat/models/chat.py
+++ b/src/gigachat/models/chat.py
@@ -73,23 +73,23 @@ class Usage(BaseModel):
 class FunctionParametersProperty(BaseModel):
     """Property of a function parameter."""
 
-    type_: str = Field(default="object", alias="type", description="Type of the argument.")
-    description: str = Field(default="", description="Description of the argument.")
-    items: Optional[Dict[str, Any]] = Field(default=None, description="Items schema for array types.")
-    enum: Optional[List[str]] = Field(default=None, description="List of possible values for enum types.")
-    properties: Optional[Dict[Any, "FunctionParametersProperty"]] = Field(
-        default=None, description="Nested properties for object types."
-    )
+    type_: Optional[Union[str, List[str]]] = Field(default=None, alias="type", description="JSON Schema type.")
+    description: Optional[str] = Field(default=None, description="Description of the argument.")
+    items: Any = Field(default=None, description="Items schema for array types.")
+    enum: Optional[List[Any]] = Field(default=None, description="List of possible values for enum types.")
+    properties: Optional[Dict[Any, Any]] = Field(default=None, description="Nested properties for object types.")
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
 
 class FunctionParameters(BaseModel):
     """Parameters definition for a function."""
 
-    type_: str = Field(default="object", alias="type", description="Type of the parameters object (usually 'object').")
-    properties: Optional[Dict[Any, FunctionParametersProperty]] = Field(
-        default=None, description="Dictionary of parameter properties."
-    )
+    type_: Optional[Union[str, List[str]]] = Field(default=None, alias="type", description="JSON Schema type.")
+    properties: Optional[Dict[Any, Any]] = Field(default=None, description="Dictionary of parameter properties.")
     required: Optional[List[str]] = Field(default=None, description="List of required parameter names.")
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
 
 class Function(BaseModel):

--- a/tests/unit/gigachat/api/test_chat.py
+++ b/tests/unit/gigachat/api/test_chat.py
@@ -22,7 +22,7 @@ from gigachat.context import (
 )
 from gigachat.exceptions import AuthenticationError, BadRequestError
 from gigachat.models import Chat, ChatCompletion, ChatCompletionChunk
-from gigachat.models.chat import Messages, MessagesRole
+from gigachat.models.chat import Function, Messages, MessagesRole
 from gigachat.models.response_format import JsonSchemaResponseFormat
 from tests.constants import (
     BASE_URL,
@@ -137,6 +137,31 @@ def test_chat_sync_additional_fields_passthrough_preset(httpx_mock: HTTPXMock) -
     assert request_content["response_format"]["type"] == "json_schema"
     assert request_content["response_format"]["schema"] == SAMPLE_SCHEMA
     assert request_content["response_format"]["strict"] is True
+
+
+def test_chat_sync_preserves_function_json_schema(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=MOCK_URL, json=CHAT_COMPLETION)
+    parameters = {
+        "$defs": {"value": {"type": ["string", "null"]}},
+        "type": "object",
+        "properties": {
+            "value": {"$ref": "#/$defs/value"},
+            "choice": {"anyOf": [{"const": "automatic"}, {"enum": [1, True, None]}]},
+            "anything": True,
+            "forbidden": False,
+        },
+        "unevaluatedProperties": False,
+    }
+    chat_data = Chat(
+        messages=[Messages(role=MessagesRole.USER, content="choose a value")],
+        functions=[Function(name="choose", parameters=parameters)],
+    )
+
+    with httpx.Client(base_url=BASE_URL) as client:
+        chat.chat_sync(client, chat=chat_data)
+
+    request_content = json.loads(httpx_mock.get_requests()[0].content.decode("utf-8"))
+    assert request_content["functions"][0]["parameters"] == parameters
 
 
 def test_chat_sync_response_format_json_schema(httpx_mock: HTTPXMock) -> None:

--- a/tests/unit/gigachat/api/test_chat_completions.py
+++ b/tests/unit/gigachat/api/test_chat_completions.py
@@ -5,7 +5,14 @@ from pytest_httpx import HTTPXMock
 
 from gigachat.api import chat_completions
 from gigachat.context import chat_completions_url_cvar
-from gigachat.models.chat_completions import ChatCompletionChunk, ChatCompletionRequest, ChatMessage, ChatStorage
+from gigachat.models.chat_completions import (
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatFunctionSpecification,
+    ChatMessage,
+    ChatStorage,
+    ChatTool,
+)
 from tests.constants import BASE_URL, HEADERS_STREAM, MOCK_URL
 
 PRIMARY_CHAT_COMPLETION_STREAM = (
@@ -93,6 +100,35 @@ def test_build_request_json_keeps_storage_object() -> None:
     request_content = chat_completions._build_request_json(chat_data)
 
     assert request_content["storage"] == {"thread_id": "thread-1", "limit": 10}
+
+
+def test_build_request_json_preserves_function_json_schema() -> None:
+    parameters = {
+        "$defs": {"value": {"type": ["string", "null"]}},
+        "type": "object",
+        "properties": {
+            "value": {"$ref": "#/$defs/value"},
+            "choice": {"anyOf": [{"const": "automatic"}, {"enum": [1, True, None]}]},
+            "anything": True,
+            "forbidden": False,
+        },
+        "unevaluatedProperties": False,
+    }
+    chat_data = ChatCompletionRequest(
+        messages=[ChatMessage(role="user", content="choose a value")],
+        tools=[
+            ChatTool(
+                functions={
+                    "specifications": [ChatFunctionSpecification(name="choose", parameters=parameters)],
+                }
+            )
+        ],
+    )
+
+    request_content = chat_completions._build_request_json(chat_data)
+    functions = request_content["tools"][0]["functions"]
+
+    assert functions["specifications"][0]["parameters"] == parameters
 
 
 def test_stream_sync_parses_primary_chunk(httpx_mock: HTTPXMock) -> None:

--- a/tests/unit/gigachat/models/test_chat.py
+++ b/tests/unit/gigachat/models/test_chat.py
@@ -27,6 +27,7 @@ from gigachat.models.chat import (
     Function,
     FunctionCall,
     FunctionParameters,
+    FunctionParametersProperty,
     FunctionRanker,
     Messages,
     MessagesRole,
@@ -91,7 +92,57 @@ def test_usage_validation() -> None:
 
 def test_function_parameters_default() -> None:
     params = FunctionParameters()
-    assert params.type_ == "object"
+    assert params.type_ is None
+    assert params.model_dump(exclude_none=True, by_alias=True) == {}
+
+
+def test_function_parameters_preserve_json_schema_without_defaults() -> None:
+    parameters = {
+        "$defs": {
+            "coordinate": {
+                "type": "number",
+                "minimum": -180,
+            }
+        },
+        "type": "object",
+        "properties": {
+            "location": {
+                "anyOf": [
+                    {"type": "string"},
+                    {
+                        "type": "array",
+                        "prefixItems": [
+                            {"$ref": "#/$defs/coordinate"},
+                            {"$ref": "#/$defs/coordinate"},
+                        ],
+                        "items": False,
+                    },
+                ]
+            },
+            "priority": {"enum": ["normal", 1, None]},
+            "anything": True,
+            "forbidden": False,
+        },
+        "required": ["location"],
+        "additionalProperties": False,
+    }
+
+    function = Function(name="route", parameters=parameters)
+
+    assert function.model_dump(exclude_none=True, by_alias=True)["parameters"] == parameters
+
+
+def test_function_parameter_property_preserves_extensions_and_union_type() -> None:
+    schema = {
+        "type": ["string", "null"],
+        "enum": ["automatic", 1, None],
+        "const": "automatic",
+        "nullable": True,
+    }
+
+    property_schema = FunctionParametersProperty.model_validate(schema)
+
+    assert property_schema.model_dump(exclude_none=True, by_alias=True) == schema
 
 
 def test_chat_function_ranker_from_dict() -> None:


### PR DESCRIPTION
## Description

Preserve native JSON Schema definitions in legacy v1 function-calling requests instead of narrowing or rewriting them in the SDK.

The v1 compatibility surface now forwards schemas with composition, references, union types, mixed enums, boolean subschemas, tuple-array keywords, and extension keywords without injecting defaults or dropping unknown fields. The primary v2 contract already stores function parameters as `Dict[str, Any]`; this PR adds a matching regression test but does not change its production model.

## Motivation

The backend accepts native function schemas in both v1 and v2 modes, but the legacy v1 SDK models previously changed them before transmission:

- omitted `type` became `"object"`;
- omitted `description` became an empty string;
- `type` accepted only a single string;
- `enum` accepted only strings;
- `items` and nested `properties` were constrained to narrow object models;
- JSON Schema keywords unknown to the model were discarded.

As a result, valid schemas using keywords such as `$defs`, `$ref`, `anyOf`, `prefixItems`, `const`, or `unevaluatedProperties` could be rejected locally or sent with different semantics.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD or tooling change

## Changes Made

- Updated `FunctionParametersProperty` in `src/gigachat/models/chat.py`:
  - `type_` accepts a string or a list of strings and is no longer synthesized when omitted;
  - `description` is optional and is no longer synthesized as an empty string;
  - `items`, `enum`, and nested `properties` preserve native JSON values;
  - additional JSON Schema keywords are retained.
- Updated `FunctionParameters` in `src/gigachat/models/chat.py`:
  - preserves union `type` values;
  - keeps nested property schemas as raw JSON-compatible mappings;
  - retains additional JSON Schema keywords;
  - no longer injects `type: object` into schemas that omit `type`.
- Added model-level regression coverage in `tests/unit/gigachat/models/test_chat.py` for `$defs`/`$ref`, `anyOf`, `prefixItems`, boolean `items`, mixed enums, boolean property schemas, and extension keywords.
- Added a v1 wire-payload regression in `tests/unit/gigachat/api/test_chat.py` for the compatibility `client.chat(...)` path and `POST /chat/completions`.
- Added a v2 wire-payload regression in `tests/unit/gigachat/api/test_chat_completions.py` for `client.chat.create(...)` and `POST /v2/chat/completions`. No v2 production change was required because `ChatFunctionSpecification.parameters` was already lossless.

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not required for the serialization-only change)
- [x] All existing tracked tests pass locally

### Manual Testing

```bash
.venv/bin/ruff check src tests
.venv/bin/ruff format --check src tests
.venv/bin/mypy src tests
.venv/bin/pytest
```

Results:

- Ruff check and format check passed.
- Strict mypy passed for 88 source files.
- Tracked test suite: 505 passed, 33 integration tests deselected.
- A local 23-schema probe confirmed lossless model and request serialization for both v1 and v2. The probe scripts and their tests are intentionally excluded from this PR.

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented the code where the behavior is not self-explanatory
- [x] My changes generate no new linter warnings (`make lint`)
- [x] Type checking passes (`make mypy`)
- [x] All tests pass (`make test`)

### Documentation

- [ ] Documentation update required
- [x] Docstrings follow Google style with imperative mood
- [ ] Public examples required
- [ ] README.md update required

### Dependencies

- [x] No new dependencies added
- [ ] If dependencies added, they are justified and minimal
- [ ] `uv.lock` updated (no dependency changes)

### Compatibility

- [x] Changes use Python 3.8-compatible typing syntax
- [x] No use of `type[...]` syntax
- [x] Sync and async requests share the corrected serialization models

### Commits

- [x] Commit messages are clear and follow conventional commits style
- [x] Commits are logically organized
- [x] No debug code or commented-out code left in

## Additional Context

The public compatibility models `FunctionParameters` and `FunctionParametersProperty` remain available. Their accepted input surface is broadened, while the only intentional behavioral change is that omitted schema fields are no longer materialized as SDK defaults.

The primary v2 function model remains unchanged because its `parameters: Dict[str, Any]` contract already preserves native schemas.

Backend probes and runnable schema examples remain local via `.git/info/exclude`; they are not part of the PR diff.

## Pre-merge Actions

- [ ] Changelog updated (if applicable)
- [ ] Version bump considered (if applicable)
