### PR TITLE
Release/v0.2.4a1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gigachat"
-version = "0.2.3"
+version = "0.2.4"
 description = "GigaChat. Python-library for GigaChat API"
 authors = [
     { name = "Konstantin Krestnikov", email = "rai220@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gigachat"
-version = "0.2.4"
+version = "0.2.4a1"
 description = "GigaChat. Python-library for GigaChat API"
 authors = [
     { name = "Konstantin Krestnikov", email = "rai220@gmail.com" },

--- a/src/gigachat/client.py
+++ b/src/gigachat/client.py
@@ -245,7 +245,10 @@ def _parse_primary_completion(
 
 
 def _build_access_token(token: Token) -> AccessToken:
-    return AccessToken(access_token=token.tok, expires_at=token.exp, x_headers=token.x_headers)
+    expires_at = token.exp
+    if expires_at < 10_000_000_000:
+        expires_at *= 1000
+    return AccessToken(access_token=token.tok, expires_at=expires_at, x_headers=token.x_headers)
 
 
 class _BaseClient:

--- a/src/gigachat/models/auth.py
+++ b/src/gigachat/models/auth.py
@@ -14,4 +14,4 @@ class Token(APIResponse):
     """Raw token response."""
 
     tok: str = Field(description="Generated Access Token.")
-    exp: int = Field(description="Unix timestamp (in milliseconds) when the Access Token expires.")
+    exp: int = Field(description="Unix timestamp (in seconds or milliseconds) when the Access Token expires.")

--- a/src/gigachat/models/chat.py
+++ b/src/gigachat/models/chat.py
@@ -73,23 +73,23 @@ class Usage(BaseModel):
 class FunctionParametersProperty(BaseModel):
     """Property of a function parameter."""
 
-    type_: str = Field(default="object", alias="type", description="Type of the argument.")
-    description: str = Field(default="", description="Description of the argument.")
-    items: Optional[Dict[str, Any]] = Field(default=None, description="Items schema for array types.")
-    enum: Optional[List[str]] = Field(default=None, description="List of possible values for enum types.")
-    properties: Optional[Dict[Any, "FunctionParametersProperty"]] = Field(
-        default=None, description="Nested properties for object types."
-    )
+    type_: Optional[Union[str, List[str]]] = Field(default=None, alias="type", description="JSON Schema type.")
+    description: Optional[str] = Field(default=None, description="Description of the argument.")
+    items: Any = Field(default=None, description="Items schema for array types.")
+    enum: Optional[List[Any]] = Field(default=None, description="List of possible values for enum types.")
+    properties: Optional[Dict[Any, Any]] = Field(default=None, description="Nested properties for object types.")
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
 
 class FunctionParameters(BaseModel):
     """Parameters definition for a function."""
 
-    type_: str = Field(default="object", alias="type", description="Type of the parameters object (usually 'object').")
-    properties: Optional[Dict[Any, FunctionParametersProperty]] = Field(
-        default=None, description="Dictionary of parameter properties."
-    )
+    type_: Optional[Union[str, List[str]]] = Field(default=None, alias="type", description="JSON Schema type.")
+    properties: Optional[Dict[Any, Any]] = Field(default=None, description="Dictionary of parameter properties.")
     required: Optional[List[str]] = Field(default=None, description="List of required parameter names.")
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
 
 class Function(BaseModel):

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -18,6 +18,10 @@ EXPIRES_AT_EXPIRED = 946684800000
 # 2100-01-01 00:00:00 UTC - always valid
 EXPIRES_AT_VALID = 4102444800000
 
+# Password auth /token returns expiration timestamps in seconds
+PASSWORD_EXPIRES_AT_EXPIRED = EXPIRES_AT_EXPIRED // 1000
+PASSWORD_EXPIRES_AT_VALID = EXPIRES_AT_VALID // 1000
+
 # Mock token string (same for all variants)
 MOCK_TOKEN_STRING = (
     "eyJlbmMiOiJBMjU2Q0JDLUhTNTEyIiwiYWxnIjoiUlNBLU9BRVAtMjU2In0."
@@ -67,8 +71,8 @@ OAUTH_TOKEN_VALID = {"access_token": MOCK_TOKEN_STRING, "expires_at": EXPIRES_AT
 OAUTH_TOKEN_EXPIRED = {"access_token": MOCK_TOKEN_STRING, "expires_at": EXPIRES_AT_EXPIRED}
 
 # Test Data - Password auth token variants (/token endpoint, tok/exp format)
-PASSWORD_TOKEN_VALID = {"tok": MOCK_TOKEN_STRING, "exp": EXPIRES_AT_VALID}
-PASSWORD_TOKEN_EXPIRED = {"tok": MOCK_TOKEN_STRING, "exp": EXPIRES_AT_EXPIRED}
+PASSWORD_TOKEN_VALID = {"tok": MOCK_TOKEN_STRING, "exp": PASSWORD_EXPIRES_AT_VALID}
+PASSWORD_TOKEN_EXPIRED = {"tok": MOCK_TOKEN_STRING, "exp": PASSWORD_EXPIRES_AT_EXPIRED}
 CHAT = Chat.model_validate(get_json("chat.json"))
 CHAT_FUNCTION = Chat.model_validate(get_json("chat_function.json"))
 CHAT_COMPLETION = get_json("chat_completion.json")

--- a/tests/unit/gigachat/api/test_chat.py
+++ b/tests/unit/gigachat/api/test_chat.py
@@ -22,7 +22,7 @@ from gigachat.context import (
 )
 from gigachat.exceptions import AuthenticationError, BadRequestError
 from gigachat.models import Chat, ChatCompletion, ChatCompletionChunk
-from gigachat.models.chat import Messages, MessagesRole
+from gigachat.models.chat import Function, Messages, MessagesRole
 from gigachat.models.response_format import JsonSchemaResponseFormat
 from tests.constants import (
     BASE_URL,
@@ -137,6 +137,31 @@ def test_chat_sync_additional_fields_passthrough_preset(httpx_mock: HTTPXMock) -
     assert request_content["response_format"]["type"] == "json_schema"
     assert request_content["response_format"]["schema"] == SAMPLE_SCHEMA
     assert request_content["response_format"]["strict"] is True
+
+
+def test_chat_sync_preserves_function_json_schema(httpx_mock: HTTPXMock) -> None:
+    httpx_mock.add_response(url=MOCK_URL, json=CHAT_COMPLETION)
+    parameters = {
+        "$defs": {"value": {"type": ["string", "null"]}},
+        "type": "object",
+        "properties": {
+            "value": {"$ref": "#/$defs/value"},
+            "choice": {"anyOf": [{"const": "automatic"}, {"enum": [1, True, None]}]},
+            "anything": True,
+            "forbidden": False,
+        },
+        "unevaluatedProperties": False,
+    }
+    chat_data = Chat(
+        messages=[Messages(role=MessagesRole.USER, content="choose a value")],
+        functions=[Function(name="choose", parameters=parameters)],
+    )
+
+    with httpx.Client(base_url=BASE_URL) as client:
+        chat.chat_sync(client, chat=chat_data)
+
+    request_content = json.loads(httpx_mock.get_requests()[0].content.decode("utf-8"))
+    assert request_content["functions"][0]["parameters"] == parameters
 
 
 def test_chat_sync_response_format_json_schema(httpx_mock: HTTPXMock) -> None:

--- a/tests/unit/gigachat/api/test_chat_completions.py
+++ b/tests/unit/gigachat/api/test_chat_completions.py
@@ -5,7 +5,14 @@ from pytest_httpx import HTTPXMock
 
 from gigachat.api import chat_completions
 from gigachat.context import chat_completions_url_cvar
-from gigachat.models.chat_completions import ChatCompletionChunk, ChatCompletionRequest, ChatMessage, ChatStorage
+from gigachat.models.chat_completions import (
+    ChatCompletionChunk,
+    ChatCompletionRequest,
+    ChatFunctionSpecification,
+    ChatMessage,
+    ChatStorage,
+    ChatTool,
+)
 from tests.constants import BASE_URL, HEADERS_STREAM, MOCK_URL
 
 PRIMARY_CHAT_COMPLETION_STREAM = (
@@ -93,6 +100,35 @@ def test_build_request_json_keeps_storage_object() -> None:
     request_content = chat_completions._build_request_json(chat_data)
 
     assert request_content["storage"] == {"thread_id": "thread-1", "limit": 10}
+
+
+def test_build_request_json_preserves_function_json_schema() -> None:
+    parameters = {
+        "$defs": {"value": {"type": ["string", "null"]}},
+        "type": "object",
+        "properties": {
+            "value": {"$ref": "#/$defs/value"},
+            "choice": {"anyOf": [{"const": "automatic"}, {"enum": [1, True, None]}]},
+            "anything": True,
+            "forbidden": False,
+        },
+        "unevaluatedProperties": False,
+    }
+    chat_data = ChatCompletionRequest(
+        messages=[ChatMessage(role="user", content="choose a value")],
+        tools=[
+            ChatTool(
+                functions={
+                    "specifications": [ChatFunctionSpecification(name="choose", parameters=parameters)],
+                }
+            )
+        ],
+    )
+
+    request_content = chat_completions._build_request_json(chat_data)
+    functions = request_content["tools"][0]["functions"]
+
+    assert functions["specifications"][0]["parameters"] == parameters
 
 
 def test_stream_sync_parses_primary_chunk(httpx_mock: HTTPXMock) -> None:

--- a/tests/unit/gigachat/models/test_chat.py
+++ b/tests/unit/gigachat/models/test_chat.py
@@ -27,6 +27,7 @@ from gigachat.models.chat import (
     Function,
     FunctionCall,
     FunctionParameters,
+    FunctionParametersProperty,
     FunctionRanker,
     Messages,
     MessagesRole,
@@ -91,7 +92,57 @@ def test_usage_validation() -> None:
 
 def test_function_parameters_default() -> None:
     params = FunctionParameters()
-    assert params.type_ == "object"
+    assert params.type_ is None
+    assert params.model_dump(exclude_none=True, by_alias=True) == {}
+
+
+def test_function_parameters_preserve_json_schema_without_defaults() -> None:
+    parameters = {
+        "$defs": {
+            "coordinate": {
+                "type": "number",
+                "minimum": -180,
+            }
+        },
+        "type": "object",
+        "properties": {
+            "location": {
+                "anyOf": [
+                    {"type": "string"},
+                    {
+                        "type": "array",
+                        "prefixItems": [
+                            {"$ref": "#/$defs/coordinate"},
+                            {"$ref": "#/$defs/coordinate"},
+                        ],
+                        "items": False,
+                    },
+                ]
+            },
+            "priority": {"enum": ["normal", 1, None]},
+            "anything": True,
+            "forbidden": False,
+        },
+        "required": ["location"],
+        "additionalProperties": False,
+    }
+
+    function = Function(name="route", parameters=parameters)
+
+    assert function.model_dump(exclude_none=True, by_alias=True)["parameters"] == parameters
+
+
+def test_function_parameter_property_preserves_extensions_and_union_type() -> None:
+    schema = {
+        "type": ["string", "null"],
+        "enum": ["automatic", 1, None],
+        "const": "automatic",
+        "nullable": True,
+    }
+
+    property_schema = FunctionParametersProperty.model_validate(schema)
+
+    assert property_schema.model_dump(exclude_none=True, by_alias=True) == schema
 
 
 def test_chat_function_ranker_from_dict() -> None:

--- a/tests/unit/gigachat/test_client_chat.py
+++ b/tests/unit/gigachat/test_client_chat.py
@@ -629,7 +629,7 @@ def test_chat_credentials_expired_token_refresh(httpx_mock: HTTPXMock) -> None:
 
 
 def test_chat_user_password_token_reuse(httpx_mock: HTTPXMock) -> None:
-    """Verify that valid token is reused with user/password auth."""
+    """Verify that a seconds-based token expiration is normalized and reused."""
     httpx_mock.add_response(url=TOKEN_URL, json=PASSWORD_TOKEN_VALID)
     httpx_mock.add_response(url=CHAT_URL, json=CHAT_COMPLETION)
     httpx_mock.add_response(url=CHAT_URL, json=CHAT_COMPLETION)
@@ -640,6 +640,7 @@ def test_chat_user_password_token_reuse(httpx_mock: HTTPXMock) -> None:
 
     assert isinstance(response1, ChatCompletion)
     assert isinstance(response2, ChatCompletion)
+    assert sum(str(request.url) == TOKEN_URL for request in httpx_mock.get_requests()) == 1
 
 
 def test_chat_user_password_expired_token_refresh(httpx_mock: HTTPXMock) -> None:
@@ -1314,7 +1315,7 @@ async def test_achat_credentials_expired_token_refresh(httpx_mock: HTTPXMock) ->
 
 
 async def test_achat_user_password_token_reuse(httpx_mock: HTTPXMock) -> None:
-    """Verify that valid token is reused with async user/password auth."""
+    """Verify that a seconds-based token expiration is normalized and reused."""
     httpx_mock.add_response(url=TOKEN_URL, json=PASSWORD_TOKEN_VALID)
     httpx_mock.add_response(url=CHAT_URL, json=CHAT_COMPLETION)
     httpx_mock.add_response(url=CHAT_URL, json=CHAT_COMPLETION)
@@ -1325,6 +1326,7 @@ async def test_achat_user_password_token_reuse(httpx_mock: HTTPXMock) -> None:
 
     assert isinstance(response1, ChatCompletion)
     assert isinstance(response2, ChatCompletion)
+    assert sum(str(request.url) == TOKEN_URL for request in httpx_mock.get_requests()) == 1
 
 
 async def test_achat_user_password_expired_token_refresh(httpx_mock: HTTPXMock) -> None:

--- a/tests/unit/gigachat/test_client_core.py
+++ b/tests/unit/gigachat/test_client_core.py
@@ -18,6 +18,7 @@ from tests.constants import (
     BASE_URL,
     CREDENTIALS,
     OAUTH_TOKEN_VALID,
+    PASSWORD_EXPIRES_AT_VALID,
     PASSWORD_TOKEN_VALID,
     TOKEN_URL,
 )
@@ -87,10 +88,10 @@ def test_get_token_password(httpx_mock: HTTPXMock) -> None:
 
     assert model._access_token is not None
     assert model._access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
+    assert model._access_token.expires_at == PASSWORD_EXPIRES_AT_VALID * 1000
     assert access_token is not None
     assert access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
+    assert access_token.expires_at == PASSWORD_EXPIRES_AT_VALID * 1000
 
 
 def test_get_token_manual() -> None:
@@ -162,10 +163,10 @@ async def test_aget_token_password(httpx_mock: HTTPXMock) -> None:
 
     assert model._access_token is not None
     assert model._access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
+    assert model._access_token.expires_at == PASSWORD_EXPIRES_AT_VALID * 1000
     assert access_token is not None
     assert access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
+    assert access_token.expires_at == PASSWORD_EXPIRES_AT_VALID * 1000
 
 
 async def test_aget_token_manual() -> None:

--- a/tests/unit/gigachat/test_client_core.py
+++ b/tests/unit/gigachat/test_client_core.py
@@ -87,10 +87,10 @@ def test_get_token_password(httpx_mock: HTTPXMock) -> None:
 
     assert model._access_token is not None
     assert model._access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"]
+    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
     assert access_token is not None
     assert access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"]
+    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
 
 
 def test_get_token_manual() -> None:
@@ -162,10 +162,10 @@ async def test_aget_token_password(httpx_mock: HTTPXMock) -> None:
 
     assert model._access_token is not None
     assert model._access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"]
+    assert model._access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
     assert access_token is not None
     assert access_token.access_token == PASSWORD_TOKEN_VALID["tok"]
-    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"]
+    assert access_token.expires_at == PASSWORD_TOKEN_VALID["exp"] * 1000
 
 
 async def test_aget_token_manual() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.4"
+version = "0.2.4a1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },

--- a/uv.lock
+++ b/uv.lock
@@ -457,7 +457,7 @@ wheels = [
 
 [[package]]
 name = "gigachat"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", version = "0.24.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },


### PR DESCRIPTION
## Description

Prepare the `0.2.4a1` release candidate by combining the two fixes developed in #123 and #124:

1. normalize second-based password-auth token expirations so the cached token is reused instead of requesting `/token` before every API call;
2. preserve native JSON Schema definitions in legacy v1 function-calling requests without narrowing fields, injecting defaults, or dropping unknown keywords.

The release branch validates both changes together and bumps the package version from `0.2.3` to `0.2.4a1`.

## Motivation

### Password-auth token reuse

The password-auth `/token` endpoint may return a 10-digit Unix expiration timestamp in seconds, while the SDK compares cached token expiration against `time.time() * 1000` in milliseconds. A seconds-based value was therefore treated as already expired, causing every subsequent API call to issue another `POST /token`.

The conversion is performed only when building the internal `AccessToken`: values below `10_000_000_000` are converted from seconds to milliseconds, while already millisecond-based values—including the OAuth path—remain unchanged.

### Native function JSON Schemas

The backend accepts native JSON Schemas in both v1 and v2 function-calling requests. The legacy v1 compatibility models previously changed valid schemas before transmission by synthesizing `type: object` and an empty `description`, restricting `type` and `enum`, narrowing nested schemas, and discarding unknown JSON Schema keywords.

This prevented lossless use of schemas containing constructs such as `$defs`, `$ref`, `anyOf`, union types, mixed enums, boolean subschemas, `prefixItems`, `const`, and extension keywords. The v1 models now preserve those values as supplied. The v2 model was already lossless and receives regression coverage only.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test coverage improvement
- [ ] CI/CD or tooling change

## Changes Made

### Token expiration normalization from #123

- Updated `src/gigachat/client.py::_build_access_token()` to normalize second-based `Token.exp` values to milliseconds while preserving millisecond-based values.
- Updated `src/gigachat/models/auth.py::Token.exp` to document that the raw endpoint value may be expressed in seconds or milliseconds; the internal `AccessToken.expires_at` contract remains millisecond-based.
- Updated password-auth fixtures in `tests/constants.py` to reflect the seconds-based `/token` response.
- Added sync and async regression assertions in `tests/unit/gigachat/test_client_chat.py` proving that two consecutive chat calls reuse one token and make exactly one `/token` request.
- Updated sync and async token-construction assertions in `tests/unit/gigachat/test_client_core.py`.

### Lossless function schemas from #124

- Broadened the public `FunctionParametersProperty` model in `src/gigachat/models/chat.py`:
  - `type_` now accepts a string or a list of strings and remains absent when omitted;
  - `description` is optional and remains absent when omitted;
  - `items` accepts any JSON-compatible schema value, including boolean schemas;
  - `enum` accepts mixed JSON values;
  - nested `properties` retain raw JSON-compatible values;
  - additional JSON Schema and extension keywords are preserved.
- Broadened the public `FunctionParameters` model in `src/gigachat/models/chat.py`:
  - `type_` accepts a string or a list of strings and no longer defaults to `object`;
  - nested `properties` are retained as raw JSON-compatible mappings;
  - additional JSON Schema and extension keywords are preserved.
- Added model-level coverage in `tests/unit/gigachat/models/test_chat.py` for definitions and references, composition, tuple-array keywords, mixed enums, boolean property schemas, union types, and extensions.
- Added a v1 wire-payload regression in `tests/unit/gigachat/api/test_chat.py` for `client.chat(...)` and `POST /chat/completions`.
- Added a v2 regression in `tests/unit/gigachat/api/test_chat_completions.py` for `client.chat.create(...)` and `POST /v2/chat/completions`. No v2 production model change was required because `ChatFunctionSpecification.parameters` already uses a lossless `Dict[str, Any]` contract.

### Release metadata

- Bumped the package version to `0.2.4a1` in `pyproject.toml` and `uv.lock`.
- Added no runtime dependencies.

## Public API and Request Behavior

| Area | Public surface | Result |
| --- | --- | --- |
| Password authentication | `Token.exp`, sync and async `GigaChat` password-auth flows | Accepts endpoint expirations in seconds or milliseconds; cached `AccessToken.expires_at` remains milliseconds. |
| Legacy v1 function calling | `Function`, `FunctionParameters`, `FunctionParametersProperty`, `client.chat(...)`, `POST /chat/completions` | Preserves native JSON Schema values and unknown keywords without SDK-generated defaults. |
| Primary v2 function calling | `ChatFunctionSpecification.parameters`, `client.chat.create(...)`, `POST /v2/chat/completions` | Production behavior is unchanged; regression coverage confirms lossless serialization. |

## Testing

### Test Coverage

- [x] Unit tests added/updated
- [x] Integration tests passed
- [x] The combined release branch passed hosted CI

### Automated Validation

[CI run 31101985215](https://github.com/ai-forever/gigachat/actions/runs/31101985215) passed on the combined PR head:

- Ruff format check and lint;
- strict mypy type checking;
- unit test matrix on Python 3.8, 3.9, 3.10, 3.11, 3.12, and 3.13;
- experimental Python 3.14 test job;
- cassette-backed integration tests.

```bash
uv run ruff format --check src tests
uv run ruff check src tests
uv run mypy src tests
uv run pytest --cov=src --cov-report=term-missing --cov-report=xml
uv run pytest -m integration --record-mode=none
```

## Checklist

### Code Quality

- [x] Code follows the project's style guidelines
- [x] I have performed a self-review of the combined diff
- [x] The behavior is covered by focused regression tests
- [x] The changes generate no new linter warnings
- [x] Type checking passes
- [x] All CI test jobs pass

### Documentation

- [x] The changed `Token.exp` contract is documented in the model field
- [x] Docstrings follow the project style
- [ ] Public examples added (not required for these fixes)
- [ ] README updated (not required for these fixes)

### Dependencies

- [x] No new dependencies added
- [ ] If dependencies were added, they are justified and minimal (not applicable)
- [x] `uv.lock` updated for the version bump

### Compatibility

- [x] Changes use Python 3.8-compatible typing syntax
- [x] No use of `type[...]` syntax
- [x] Sync and async password-auth flows are covered
- [x] Required Python 3.8-3.13 CI matrix passes

### Commits

- [x] Commit messages follow conventional commits style
- [x] Changes from #123 and #124 remain logically separated in history
- [x] No debug code or commented-out code is included

## Additional Context

This PR is the release integration point for #123 and #124. The public compatibility models `FunctionParameters` and `FunctionParametersProperty` remain available; their accepted input surface is broadened. The intentional serialization change is that omitted schema fields are no longer materialized as SDK defaults.

OAuth expiration handling and the production v2 function model are unchanged.

## Pre-merge Actions

- [ ] Changelog updated (if applicable)
- [x] Version bump applied (`0.2.4a1`)